### PR TITLE
AV-383: debounce search queries

### DIFF
--- a/graphql-codegen/graphql-plugin-getters.ts
+++ b/graphql-codegen/graphql-plugin-getters.ts
@@ -56,7 +56,7 @@ const plugin: CodegenPlugin = {
 
 		if (!result) return '';
 
-		return `import { fetchApi } from '~lib/api/fetchApi' \n${result}`;
+		return `import { fetchApi } from '~lib/api/fetchApi';\nimport { ExactAlt } from '~src/types/types';\n${result}`;
 	},
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
                 "sass": "^1.42.1",
                 "striptags": "^3.2.0",
                 "swiper": "^9.3.2",
+                "use-debounce": "^9.0.4",
                 "video.js": "^7.21.1"
             },
             "devDependencies": {
@@ -9632,9 +9633,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001506",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
-            "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
+            "version": "1.0.30001508",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
+            "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -22593,6 +22594,17 @@
             "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
             "dev": true
         },
+        "node_modules/use-debounce": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-9.0.4.tgz",
+            "integrity": "sha512-6X8H/mikbrt0XE8e+JXRtZ8yYVvKkdYRfmIhWZYsP8rcNs9hk3APV8Ua2mFkKRLcJKVdnX2/Vwrmg2GWKUQEaQ==",
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
         "node_modules/use-sync-external-store": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -30669,9 +30681,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001506",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
-            "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw=="
+            "version": "1.0.30001508",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
+            "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw=="
         },
         "capital-case": {
             "version": "1.0.4",
@@ -40593,6 +40605,12 @@
             "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
             "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
             "dev": true
+        },
+        "use-debounce": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-9.0.4.tgz",
+            "integrity": "sha512-6X8H/mikbrt0XE8e+JXRtZ8yYVvKkdYRfmIhWZYsP8rcNs9hk3APV8Ua2mFkKRLcJKVdnX2/Vwrmg2GWKUQEaQ==",
+            "requires": {}
         },
         "use-sync-external-store": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "sass": "^1.42.1",
         "striptags": "^3.2.0",
         "swiper": "^9.3.2",
+        "use-debounce": "^9.0.4",
         "video.js": "^7.21.1"
     },
     "devDependencies": {

--- a/public/compiled-lang/en.json
+++ b/public/compiled-lang/en.json
@@ -4603,6 +4603,18 @@
       "value": "See All Matching Conferences"
     }
   ],
+  "search__emptyStateMessage": [
+    {
+      "type": 0,
+      "value": "Try searching for something else"
+    }
+  ],
+  "search__emptyStateTitle": [
+    {
+      "type": 0,
+      "value": "No results found"
+    }
+  ],
   "search__musicHeading": [
     {
       "type": 0,

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -2196,6 +2196,12 @@
   "search__conferencesSeeAll": {
     "string": "See All Matching Conferences"
   },
+  "search__emptyStateMessage": {
+    "string": "Try searching for something else"
+  },
+  "search__emptyStateTitle": {
+    "string": "No results found"
+  },
   "search__musicHeading": {
     "string": "Music"
   },

--- a/src/components/HOCs/__generated__/withAuthGuard.ts
+++ b/src/components/HOCs/__generated__/withAuthGuard.ts
@@ -45,7 +45,8 @@ export const useInfiniteGetWithAuthGuardDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getWithAuthGuardData<T>(
 	variables: ExactAlt<T, GetWithAuthGuardDataQueryVariables>

--- a/src/components/HOCs/withFailStates.tsx
+++ b/src/components/HOCs/withFailStates.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import LoadingCards from '~components/molecules/loadingCards';
 import NotFoundBase from '~components/organisms/notFound';
+import { Must } from '~src/types/types';
 
 type WithFailStateOptions<P> = {
 	useShould404?: (props: P) => boolean;

--- a/src/components/molecules/__generated__/helpWidget.ts
+++ b/src/components/molecules/__generated__/helpWidget.ts
@@ -58,7 +58,8 @@ export const useInfiniteGetHelpWidgetDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getHelpWidgetData<T>(
 	variables: ExactAlt<T, GetHelpWidgetDataQueryVariables>

--- a/src/components/molecules/__generated__/login.ts
+++ b/src/components/molecules/__generated__/login.ts
@@ -29,7 +29,8 @@ export const useLoginForgotPasswordMutation = <
       (variables?: LoginForgotPasswordMutationVariables) => graphqlFetcher<LoginForgotPasswordMutation, LoginForgotPasswordMutationVariables>(LoginForgotPasswordDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function loginForgotPassword<T>(
 	variables: ExactAlt<T, LoginForgotPasswordMutationVariables>

--- a/src/components/molecules/card/sermon.spec.tsx
+++ b/src/components/molecules/card/sermon.spec.tsx
@@ -47,13 +47,6 @@ describe('card sermon', () => {
 		expect(getByLabelText('play')).toBeInTheDocument();
 	});
 
-	// TODO: fix when usePlaybackSession returns server-side progress
-	// it('disables progress bar interactivity', async () => {
-	// 	const { getByLabelText } = await renderComponent();
-
-	// 	expect(getByLabelText('progress')).toBeDisabled();
-	// });
-
 	it('does not render 0 if 0 duration', async () => {
 		const { queryByText } = await renderComponent({
 			props: {
@@ -61,27 +54,12 @@ describe('card sermon', () => {
 					id: 'the_recording_id',
 					canonicalPath: 'the_sermon_path',
 					persons: [],
+					duration: 0,
 				},
-				duration: 0,
 			},
 		});
 
 		expect(queryByText('0')).not.toBeInTheDocument();
-	});
-
-	it('does not render progress if no progress', async () => {
-		const { queryByLabelText } = await renderComponent({
-			props: {
-				recording: {
-					id: 'the_recording_id',
-					canonicalPath: 'the_sermon_path',
-					persons: [],
-				},
-				progress: 0,
-			},
-		});
-
-		expect(queryByLabelText('progress')).not.toBeInTheDocument();
 	});
 
 	it('has favorite button', async () => {

--- a/src/components/organisms/__generated__/notFound.ts
+++ b/src/components/organisms/__generated__/notFound.ts
@@ -55,7 +55,8 @@ export const useInfiniteGetNotFoundPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getNotFoundPageData<T>(
 	variables: ExactAlt<T, GetNotFoundPageDataQueryVariables>

--- a/src/components/organisms/__generated__/searchResults.ts
+++ b/src/components/organisms/__generated__/searchResults.ts
@@ -449,7 +449,8 @@ export const useInfiniteGetSearchStoryProgramsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchRecordings<T>(
 	variables: ExactAlt<T, GetSearchRecordingsQueryVariables>

--- a/src/components/organisms/searchResults.tsx
+++ b/src/components/organisms/searchResults.tsx
@@ -72,27 +72,28 @@ function Section({
 	return (
 		<div className={styles.section}>
 			<LineHeading variant="overline">{section.heading}</LineHeading>
-			<CardGroup>
-				{nodes.map((e: InferrableEntity) => (
-					<CardInferred key={e.id} entity={e} />
-				))}
-				{nodes.length === 0 && (
-					<EmptyState
-						title={
-							<FormattedMessage
-								id="search__emptyStateTitle"
-								defaultMessage="No results found"
-							/>
-						}
-						message={
-							<FormattedMessage
-								id="search__emptyStateMessage"
-								defaultMessage="Try searching for something else"
-							/>
-						}
-					/>
-				)}
-			</CardGroup>
+			{nodes.length ? (
+				<CardGroup>
+					{nodes.map((e: InferrableEntity) => (
+						<CardInferred key={e.id} entity={e} />
+					))}
+				</CardGroup>
+			) : (
+				<EmptyState
+					title={
+						<FormattedMessage
+							id="search__emptyStateTitle"
+							defaultMessage="No results found"
+						/>
+					}
+					message={
+						<FormattedMessage
+							id="search__emptyStateMessage"
+							defaultMessage="Try searching for something else"
+						/>
+					}
+				/>
+			)}
 			{section.hasNextPage && entityType === 'all' && (
 				<Button
 					type="secondary"

--- a/src/components/organisms/searchResults.tsx
+++ b/src/components/organisms/searchResults.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import React, { RefObject, useEffect, useMemo, useRef, useState } from 'react';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';
 import Button from '~components/molecules/button';
@@ -14,6 +14,7 @@ import isServerSide from '~lib/isServerSide';
 import { useQueryString } from '~lib/useQueryString';
 
 import ForwardIcon from '../../../public/img/icons/icon-forward-light.svg';
+import EmptyState from './emptyState';
 import { EntityFilterId } from './searchResults.filters';
 import styles from './searchResults.module.scss';
 import useSearch, { AugmentedFilter } from './searchResults.useResults';
@@ -75,6 +76,22 @@ function Section({
 				{nodes.map((e: InferrableEntity) => (
 					<CardInferred key={e.id} entity={e} />
 				))}
+				{nodes.length === 0 && (
+					<EmptyState
+						title={
+							<FormattedMessage
+								id="search__emptyStateTitle"
+								defaultMessage="No results found"
+							/>
+						}
+						message={
+							<FormattedMessage
+								id="search__emptyStateMessage"
+								defaultMessage="Try searching for something else"
+							/>
+						}
+					/>
+				)}
 			</CardGroup>
 			{section.hasNextPage && entityType === 'all' && (
 				<Button

--- a/src/components/organisms/searchResults.tsx
+++ b/src/components/organisms/searchResults.tsx
@@ -122,7 +122,7 @@ function hasExactMatch(term: string, sections: AugmentedFilter[]): boolean {
 
 export default function Search({
 	term,
-	entityType,
+	entityType = 'all',
 	onEntityTypeChange,
 }: {
 	term?: string;

--- a/src/components/templates/__generated__/andMiniplayer.ts
+++ b/src/components/templates/__generated__/andMiniplayer.ts
@@ -112,7 +112,8 @@ export const useRecordingPlaybackProgressSetMutation = <
       (variables?: RecordingPlaybackProgressSetMutationVariables) => graphqlFetcher<RecordingPlaybackProgressSetMutation, RecordingPlaybackProgressSetMutationVariables>(RecordingPlaybackProgressSetDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getRecordingPlaybackProgress<T>(
 	variables: ExactAlt<T, GetRecordingPlaybackProgressQueryVariables>

--- a/src/components/templates/andNavigation.spec.tsx
+++ b/src/components/templates/andNavigation.spec.tsx
@@ -93,9 +93,7 @@ describe('AndNavigation', () => {
 			name: 'Presenters',
 		});
 
-		expect(teachingsHeading.compareDocumentPosition(presentersHeading)).toBe(
-			Node.DOCUMENT_POSITION_FOLLOWING
-		);
+		expect(teachingsHeading).toAppearBefore(presentersHeading);
 	});
 
 	it('ignores case when hoisting teachings', async () => {
@@ -113,9 +111,7 @@ describe('AndNavigation', () => {
 			name: 'Presenters',
 		});
 
-		expect(teachingsHeading.compareDocumentPosition(presentersHeading)).toBe(
-			Node.DOCUMENT_POSITION_FOLLOWING
-		);
+		expect(teachingsHeading).toAppearBefore(presentersHeading);
 	});
 
 	it('ignores punctuation when hoisting teachings', async () => {
@@ -133,9 +129,7 @@ describe('AndNavigation', () => {
 			name: 'Presenters',
 		});
 
-		expect(teachingsHeading.compareDocumentPosition(presentersHeading)).toBe(
-			Node.DOCUMENT_POSITION_FOLLOWING
-		);
+		expect(teachingsHeading).toAppearBefore(presentersHeading);
 	});
 
 	it('debounces search queries', async () => {

--- a/src/components/templates/andNavigation.spec.tsx
+++ b/src/components/templates/andNavigation.spec.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { CardPersonFragment } from '~components/molecules/card/__generated__/person';
 import { CardRecordingFragment } from '~components/molecules/card/__generated__/recording';
 import {
+	GetSearchAudiobooksDocument,
 	GetSearchPersonsDocument,
 	GetSearchRecordingsDocument,
 } from '~components/organisms/__generated__/searchResults';
@@ -153,6 +154,56 @@ describe('AndNavigation', () => {
 				expect.objectContaining({
 					variables: expect.objectContaining({
 						term: 'abc',
+					}),
+				})
+			);
+		});
+
+		expect(fetchApi).not.toBeCalledWith(
+			GetSearchRecordingsDocument,
+			expect.objectContaining({
+				variables: expect.objectContaining({
+					term: 'ab',
+				}),
+			})
+		);
+	});
+
+	it('disables queries for inactive tabs', async () => {
+		const user = userEvent.setup();
+
+		await renderTemplate();
+
+		const searchInputs = screen.getAllByPlaceholderText('Search');
+		const search = searchInputs[0];
+
+		await user.type(search, 'a');
+
+		await waitFor(() => {
+			expect(fetchApi).toBeCalledWith(
+				GetSearchRecordingsDocument,
+				expect.objectContaining({
+					variables: expect.objectContaining({
+						term: 'a',
+					}),
+				})
+			);
+		});
+
+		const tabs = await screen.findAllByRole('button', {
+			name: 'Audiobooks',
+		});
+
+		user.click(tabs[0]);
+
+		await user.type(search, 'b');
+
+		await waitFor(() => {
+			expect(fetchApi).toBeCalledWith(
+				GetSearchAudiobooksDocument,
+				expect.objectContaining({
+					variables: expect.objectContaining({
+						term: 'ab',
 					}),
 				})
 			);

--- a/src/containers/__generated__/blog.ts
+++ b/src/containers/__generated__/blog.ts
@@ -100,7 +100,8 @@ export const useInfiniteGetBlogPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getBlogPageData<T>(
 	variables: ExactAlt<T, GetBlogPageDataQueryVariables>

--- a/src/containers/__generated__/contact.ts
+++ b/src/containers/__generated__/contact.ts
@@ -33,7 +33,8 @@ export const useSubmitContactPageMutation = <
       (variables?: SubmitContactPageMutationVariables) => graphqlFetcher<SubmitContactPageMutation, SubmitContactPageMutationVariables>(SubmitContactPageDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function submitContactPage<T>(
 	variables: ExactAlt<T, SubmitContactPageMutationVariables>

--- a/src/containers/__generated__/home.ts
+++ b/src/containers/__generated__/home.ts
@@ -86,7 +86,8 @@ export const useInfiniteGetHomeStaticPropsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getHomeStaticProps<T>(
 	variables: ExactAlt<T, GetHomeStaticPropsQueryVariables>

--- a/src/containers/__generated__/testimonies.ts
+++ b/src/containers/__generated__/testimonies.ts
@@ -101,7 +101,8 @@ export const useInfiniteGetTestimoniesPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getTestimoniesPageData<T>(
 	variables: ExactAlt<T, GetTestimoniesPageDataQueryVariables>

--- a/src/containers/about/__generated__/index.ts
+++ b/src/containers/about/__generated__/index.ts
@@ -92,7 +92,8 @@ export const useInfiniteGetAboutStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAboutPageData<T>(
 	variables: ExactAlt<T, GetAboutPageDataQueryVariables>

--- a/src/containers/about/index.tsx
+++ b/src/containers/about/index.tsx
@@ -4,6 +4,7 @@ import Heading1 from '~components/atoms/heading1';
 import withFailStates from '~components/HOCs/withFailStates';
 import ContentWidthLimiter from '~components/molecules/contentWidthLimiter';
 import AboutNav from '~components/organisms/aboutNav';
+import { Must } from '~src/types/types';
 
 import { GetAboutPageDataQuery } from './__generated__';
 import styles from './index.module.scss';

--- a/src/containers/account/__generated__/preferences.ts
+++ b/src/containers/account/__generated__/preferences.ts
@@ -88,7 +88,8 @@ export const useUpdateAccountPreferencesMutation = <
       (variables?: UpdateAccountPreferencesMutationVariables) => graphqlFetcher<UpdateAccountPreferencesMutation, UpdateAccountPreferencesMutationVariables>(UpdateAccountPreferencesDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAccountPreferencesData<T>(
 	variables: ExactAlt<T, GetAccountPreferencesDataQueryVariables>

--- a/src/containers/account/__generated__/profile.ts
+++ b/src/containers/account/__generated__/profile.ts
@@ -120,7 +120,8 @@ export const useDeleteAccountMutation = <
       (variables?: DeleteAccountMutationVariables) => graphqlFetcher<DeleteAccountMutation, DeleteAccountMutationVariables>(DeleteAccountDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getProfileData<T>(
 	variables: ExactAlt<T, GetProfileDataQueryVariables>

--- a/src/containers/account/__generated__/register.ts
+++ b/src/containers/account/__generated__/register.ts
@@ -70,7 +70,8 @@ export const useRegisterSocialMutation = <
       (variables?: RegisterSocialMutationVariables) => graphqlFetcher<RegisterSocialMutation, RegisterSocialMutationVariables>(RegisterSocialDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function register<T>(
 	variables: ExactAlt<T, RegisterMutationVariables>

--- a/src/containers/account/__generated__/reset.ts
+++ b/src/containers/account/__generated__/reset.ts
@@ -30,7 +30,8 @@ export const useResetPasswordMutation = <
       (variables?: ResetPasswordMutationVariables) => graphqlFetcher<ResetPasswordMutation, ResetPasswordMutationVariables>(ResetPasswordDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function resetPassword<T>(
 	variables: ExactAlt<T, ResetPasswordMutationVariables>

--- a/src/containers/account/logout.spec.tsx
+++ b/src/containers/account/logout.spec.tsx
@@ -14,7 +14,7 @@ describe('logout route', () => {
 		mockUseLogout.mockResolvedValue(undefined);
 
 		await act(async () => {
-			await renderPage({ router: { push: () => Promise.resolve(true) } });
+			await renderPage();
 		});
 
 		expect(useLogout).toBeCalled();

--- a/src/containers/account/register.spec.tsx
+++ b/src/containers/account/register.spec.tsx
@@ -18,35 +18,31 @@ jest.mock('react-google-login');
 
 const renderPage = buildRenderer(Register);
 
-const router = { push: () => jest.fn().mockResolvedValue(true) } as any;
-
 describe('register page', () => {
 	beforeEach(() => {
 		Cookie.get = jest.fn().mockReturnValue({});
 	});
 
 	it('renders email field', async () => {
-		const { getByPlaceholderText } = await renderPage({ router });
+		const { getByPlaceholderText } = await renderPage();
 
 		expect(getByPlaceholderText('jane@example.com')).toBeInTheDocument();
 	});
 
 	it('renders password field', async () => {
-		const { getByPlaceholderText } = await renderPage({ router });
+		const { getByPlaceholderText } = await renderPage();
 
 		expect(getByPlaceholderText('∗∗∗∗∗∗∗')).toBeInTheDocument();
 	});
 
 	it('renders sign up button', async () => {
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		expect(getByText('Sign up')).toBeInTheDocument();
 	});
 
 	it('resets errors on click', async () => {
-		const { getByText, getByPlaceholderText, queryByText } = await renderPage({
-			router,
-		});
+		const { getByText, getByPlaceholderText, queryByText } = await renderPage();
 
 		await userEvent.click(getByText('Sign up'));
 
@@ -58,7 +54,7 @@ describe('register page', () => {
 	});
 
 	it('renders missing email error', async () => {
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(getByText('Sign up'));
 
@@ -66,7 +62,7 @@ describe('register page', () => {
 	});
 
 	it('registers user', async () => {
-		const { getByText, getByPlaceholderText } = await renderPage({ router });
+		const { getByText, getByPlaceholderText } = await renderPage();
 
 		await userEvent.type(getByPlaceholderText('Jane'), 'Matthew');
 		await userEvent.type(getByPlaceholderText('Doe'), 'Leffler');
@@ -88,7 +84,7 @@ describe('register page', () => {
 	});
 
 	it('displays loading state', async () => {
-		const { getByText, getByPlaceholderText } = await renderPage({ router });
+		const { getByText, getByPlaceholderText } = await renderPage();
 
 		await userEvent.type(getByPlaceholderText('jane@example.com'), 'email');
 		await userEvent.type(getByPlaceholderText('∗∗∗∗∗∗∗'), 'pass');
@@ -113,7 +109,7 @@ describe('register page', () => {
 				},
 			});
 
-		const { getByText, getByPlaceholderText } = await renderPage({ router });
+		const { getByText, getByPlaceholderText } = await renderPage();
 
 		await userEvent.type(getByPlaceholderText('jane@example.com'), 'email');
 		await userEvent.type(getByPlaceholderText('∗∗∗∗∗∗∗'), 'pass');
@@ -123,7 +119,7 @@ describe('register page', () => {
 	});
 
 	it('displays success message', async () => {
-		const { getByText, getByPlaceholderText } = await renderPage({ router });
+		const { getByText, getByPlaceholderText } = await renderPage();
 
 		await userEvent.type(getByPlaceholderText('jane@example.com'), 'email');
 		await userEvent.type(getByPlaceholderText('∗∗∗∗∗∗∗'), 'pass');
@@ -136,7 +132,7 @@ describe('register page', () => {
 	});
 
 	it('renders continue with Facebook', async () => {
-		await renderPage({ router });
+		await renderPage();
 
 		expect(
 			await screen.findByText('Sign up with Facebook')
@@ -144,7 +140,7 @@ describe('register page', () => {
 	});
 
 	it('renders continue with Google', async () => {
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		expect(getByText('Sign up with Google')).toBeInTheDocument();
 	});
@@ -162,7 +158,7 @@ describe('register page', () => {
 				},
 			});
 
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(getByText('Sign up with Google'));
 
@@ -184,7 +180,7 @@ describe('register page', () => {
 				},
 			});
 
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -194,7 +190,7 @@ describe('register page', () => {
 	});
 
 	it('renders social login success', async () => {
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -204,7 +200,7 @@ describe('register page', () => {
 	});
 
 	it('hits api with facebook registration', async () => {
-		await renderPage({ router });
+		await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -232,7 +228,7 @@ describe('register page', () => {
 				},
 			});
 
-		await renderPage({ router });
+		await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -248,7 +244,7 @@ describe('register page', () => {
 			status: 300,
 		});
 
-		await renderPage({ router });
+		await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -266,7 +262,7 @@ describe('register page', () => {
 			statusText: 'FAILED',
 		});
 
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -280,13 +276,13 @@ describe('register page', () => {
 	it('does not display form if user logged in', async () => {
 		Cookie.get = jest.fn().mockReturnValue({ avSession: 'abc123' });
 
-		const { queryByPlaceholderText } = await renderPage({ router });
+		const { queryByPlaceholderText } = await renderPage();
 
 		expect(queryByPlaceholderText('email')).not.toBeInTheDocument();
 	});
 
 	it('sends Google login data to API', async () => {
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(getByText('Sign up with Google'));
 

--- a/src/containers/audiobook/__generated__/detail.ts
+++ b/src/containers/audiobook/__generated__/detail.ts
@@ -163,7 +163,8 @@ export const useInfiniteGetAudiobookDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobookDetailPageData<T>(
 	variables: ExactAlt<T, GetAudiobookDetailPageDataQueryVariables>

--- a/src/containers/audiobook/__generated__/list.ts
+++ b/src/containers/audiobook/__generated__/list.ts
@@ -102,7 +102,8 @@ export const useInfiniteGetAudiobookListPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobookListPageData<T>(
 	variables: ExactAlt<T, GetAudiobookListPageDataQueryVariables>

--- a/src/containers/audiobook/tracks/__generated__/detail.ts
+++ b/src/containers/audiobook/tracks/__generated__/detail.ts
@@ -106,7 +106,8 @@ export const useInfiniteGetAudiobookTrackDetailStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobookTrackDetailData<T>(
 	variables: ExactAlt<T, GetAudiobookTrackDetailDataQueryVariables>

--- a/src/containers/bible/__generated__/book.ts
+++ b/src/containers/bible/__generated__/book.ts
@@ -105,7 +105,8 @@ export const useInfiniteGetAudiobibleBookPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobibleBookDetailData<T>(
 	variables: ExactAlt<T, GetAudiobibleBookDetailDataQueryVariables>

--- a/src/containers/bible/__generated__/version.ts
+++ b/src/containers/bible/__generated__/version.ts
@@ -61,7 +61,8 @@ export const useInfiniteGetAudiobibleVersionDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobibleVersionData<T>(
 	variables: ExactAlt<T, GetAudiobibleVersionDataQueryVariables>

--- a/src/containers/bible/__generated__/versions.ts
+++ b/src/containers/bible/__generated__/versions.ts
@@ -64,7 +64,8 @@ export const useInfiniteGetAudiobibleVersionsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobibleVersionsData<T>(
 	variables: ExactAlt<T, GetAudiobibleVersionsDataQueryVariables>

--- a/src/containers/bible/book.tsx
+++ b/src/containers/bible/book.tsx
@@ -28,6 +28,7 @@ import { BaseColors } from '~lib/constants';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
 import { RecordingContentType } from '~src/__generated__/graphql';
+import { Must } from '~src/types/types';
 
 import IconBack from '../../../public/img/icons/icon-back-light.svg';
 import IconBlog from '../../../public/img/icons/icon-blog-light-small.svg';

--- a/src/containers/bible/version.tsx
+++ b/src/containers/bible/version.tsx
@@ -17,6 +17,7 @@ import DefinitionList, {
 import Tease from '~components/molecules/tease';
 import { IBibleVersion } from '~lib/api/bibleBrain';
 import { BaseColors } from '~lib/constants';
+import { Must } from '~src/types/types';
 
 import { GetAudiobibleVersionDataQuery } from './__generated__/version';
 import styles from './version.module.scss';

--- a/src/containers/blog/__generated__/detail.ts
+++ b/src/containers/blog/__generated__/detail.ts
@@ -110,7 +110,8 @@ export const useInfiniteGetBlogDetailStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getBlogDetailData<T>(
 	variables: ExactAlt<T, GetBlogDetailDataQueryVariables>

--- a/src/containers/blog/detail.tsx
+++ b/src/containers/blog/detail.tsx
@@ -10,6 +10,7 @@ import CardPost from '~components/molecules/card/post';
 import { BaseColors } from '~lib/constants';
 import { formatLongDate } from '~lib/date';
 import { useFormattedDuration } from '~lib/time';
+import { Must } from '~src/types/types';
 
 import { GetBlogDetailDataQuery } from './__generated__/detail';
 import styles from './detail.module.scss';

--- a/src/containers/collection/__generated__/detail.ts
+++ b/src/containers/collection/__generated__/detail.ts
@@ -218,7 +218,8 @@ export const useInfiniteGetCollectionDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCollectionDetailPageData<T>(
 	variables: ExactAlt<T, GetCollectionDetailPageDataQueryVariables>

--- a/src/containers/collection/__generated__/list.ts
+++ b/src/containers/collection/__generated__/list.ts
@@ -100,7 +100,8 @@ export const useInfiniteGetCollectionListPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCollectionListPageData<T>(
 	variables: ExactAlt<T, GetCollectionListPageDataQueryVariables>

--- a/src/containers/collection/__generated__/presenters.ts
+++ b/src/containers/collection/__generated__/presenters.ts
@@ -63,7 +63,8 @@ export const useInfiniteGetCollectionPresentersPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCollectionPresentersPageData<T>(
 	variables: ExactAlt<T, GetCollectionPresentersPageDataQueryVariables>

--- a/src/containers/collection/__generated__/sequences.ts
+++ b/src/containers/collection/__generated__/sequences.ts
@@ -64,7 +64,8 @@ export const useInfiniteGetCollectionSequencesPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCollectionSequencesPageData<T>(
 	variables: ExactAlt<T, GetCollectionSequencesPageDataQueryVariables>

--- a/src/containers/collection/__generated__/teachings.ts
+++ b/src/containers/collection/__generated__/teachings.ts
@@ -73,7 +73,8 @@ export const useInfiniteGetCollectionTeachingsPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCollectionTeachingsPageData<T>(
 	variables: ExactAlt<T, GetCollectionTeachingsPageDataQueryVariables>

--- a/src/containers/collection/detail.tsx
+++ b/src/containers/collection/detail.tsx
@@ -28,6 +28,7 @@ import { formatDateRange } from '~lib/date';
 import root from '~lib/routes';
 import { useFormattedDuration } from '~lib/time';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import ForwardIcon from '../../../public/img/icons/icon-forward-light.svg';
 import { GetCollectionDetailPageDataQuery } from './__generated__/detail';

--- a/src/containers/collection/presenters.tsx
+++ b/src/containers/collection/presenters.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { CollectionPivotFragment } from './__generated__/pivot';
 import { GetCollectionPresentersPageDataQuery } from './__generated__/presenters';

--- a/src/containers/collection/sequences.tsx
+++ b/src/containers/collection/sequences.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { CollectionPivotFragment } from './__generated__/pivot';
 import { GetCollectionSequencesPageDataQuery } from './__generated__/sequences';

--- a/src/containers/collection/teachings.tsx
+++ b/src/containers/collection/teachings.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { CollectionPivotFragment } from './__generated__/pivot';
 import { GetCollectionTeachingsPageDataQuery } from './__generated__/teachings';

--- a/src/containers/contact.tsx
+++ b/src/containers/contact.tsx
@@ -12,6 +12,7 @@ import Select from '~components/molecules/form/select';
 import Textarea from '~components/molecules/form/textarea';
 import { useLanguageId } from '~lib/useLanguageId';
 import { PageContactRecipient } from '~src/__generated__/graphql';
+import { Must } from '~src/types/types';
 
 import { useSubmitContactPageMutation } from './__generated__/contact';
 import styles from './contact.module.scss';

--- a/src/containers/discover/__generated__/collections.ts
+++ b/src/containers/discover/__generated__/collections.ts
@@ -130,7 +130,8 @@ export const useInfiniteGetDiscoverCollectionsPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getDiscoverCollectionsPageData<T>(
 	variables: ExactAlt<T, GetDiscoverCollectionsPageDataQueryVariables>

--- a/src/containers/discover/__generated__/index.ts
+++ b/src/containers/discover/__generated__/index.ts
@@ -385,7 +385,8 @@ export const useInfiniteGetDiscoverBlogPostsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getDiscoverRecentTeachings<T>(
 	variables: ExactAlt<T, GetDiscoverRecentTeachingsQueryVariables>

--- a/src/containers/discover/index.slider.spec.tsx
+++ b/src/containers/discover/index.slider.spec.tsx
@@ -78,14 +78,11 @@ describe('Slider', () => {
 	});
 
 	it('calls onIndexChange', async () => {
-		const items = [
-			<div key="1">1</div>,
-			<div key="2">2</div>,
-		] as any as HTMLElement[];
+		const items = [<div key="1">1</div>, <div key="2">2</div>];
 
 		__swiper.isEnd = false;
 		__swiper.realIndex = 1;
-		__swiper.slides = items;
+		__swiper.slides = items as any;
 
 		const onIndexChange = jest.fn();
 

--- a/src/containers/library/__generated__/history.ts
+++ b/src/containers/library/__generated__/history.ts
@@ -76,7 +76,8 @@ export const useInfiniteGetLibraryHistoryPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getLibraryHistoryPageData<T>(
 	variables: ExactAlt<T, GetLibraryHistoryPageDataQueryVariables>

--- a/src/containers/library/__generated__/library.ts
+++ b/src/containers/library/__generated__/library.ts
@@ -99,7 +99,8 @@ export const useInfiniteGetLibraryDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getLibraryData<T>(
 	variables: ExactAlt<T, GetLibraryDataQueryVariables>

--- a/src/containers/library/playlist/__generated__/detail.ts
+++ b/src/containers/library/playlist/__generated__/detail.ts
@@ -69,7 +69,8 @@ export const useInfiniteGetLibraryPlaylistPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getLibraryPlaylistPageData<T>(
 	variables: ExactAlt<T, GetLibraryPlaylistPageDataQueryVariables>

--- a/src/containers/library/playlist/__generated__/list.ts
+++ b/src/containers/library/playlist/__generated__/list.ts
@@ -67,7 +67,8 @@ export const useInfiniteGetLibraryPlaylistsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getLibraryPlaylistsData<T>(
 	variables: ExactAlt<T, GetLibraryPlaylistsDataQueryVariables>

--- a/src/containers/library/playlist/detail.tsx
+++ b/src/containers/library/playlist/detail.tsx
@@ -16,6 +16,7 @@ import Tease from '~components/molecules/tease';
 import TypeLockup from '~components/molecules/typeLockup';
 import { BaseColors } from '~lib/constants';
 import { formatLongDateTime } from '~lib/date';
+import { Must } from '~src/types/types';
 
 import ListIcon from '../../../../public/img/icons/fa-list.svg';
 import LikeActiveIcon from '../../../../public/img/icons/icon-like-active.svg';

--- a/src/containers/page/__generated__/detail.ts
+++ b/src/containers/page/__generated__/detail.ts
@@ -93,7 +93,8 @@ export const useInfiniteGetCustomDetailPageStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCustomDetailPageData<T>(
 	variables: ExactAlt<T, GetCustomDetailPageDataQueryVariables>

--- a/src/containers/page/detail.tsx
+++ b/src/containers/page/detail.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Heading1 from '~components/atoms/heading1';
 import withFailStates from '~components/HOCs/withFailStates';
 import ContentWidthLimiter from '~components/molecules/contentWidthLimiter';
+import { Must } from '~src/types/types';
 
 import { GetCustomDetailPageDataQuery } from './__generated__/detail';
 

--- a/src/containers/presenter/__generated__/appears.ts
+++ b/src/containers/presenter/__generated__/appears.ts
@@ -65,7 +65,8 @@ export const useInfiniteGetPresenterAppearsPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterAppearsPageData<T>(
 	variables: ExactAlt<T, GetPresenterAppearsPageDataQueryVariables>

--- a/src/containers/presenter/__generated__/detail.ts
+++ b/src/containers/presenter/__generated__/detail.ts
@@ -199,7 +199,8 @@ export const useInfiniteGetPresenterDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterDetailPageData<T>(
 	variables: ExactAlt<T, GetPresenterDetailPageDataQueryVariables>

--- a/src/containers/presenter/__generated__/recordings.ts
+++ b/src/containers/presenter/__generated__/recordings.ts
@@ -125,7 +125,8 @@ export const useInfiniteGetPresenterRecordingsFeedDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterRecordingsPageData<T>(
 	variables: ExactAlt<T, GetPresenterRecordingsPageDataQueryVariables>

--- a/src/containers/presenter/__generated__/sequences.ts
+++ b/src/containers/presenter/__generated__/sequences.ts
@@ -67,7 +67,8 @@ export const useInfiniteGetPresenterSequencesPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterSequencesPageData<T>(
 	variables: ExactAlt<T, GetPresenterSequencesPageDataQueryVariables>

--- a/src/containers/presenter/__generated__/top.ts
+++ b/src/containers/presenter/__generated__/top.ts
@@ -73,7 +73,8 @@ export const useInfiniteGetPresenterTopPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterTopPageData<T>(
 	variables: ExactAlt<T, GetPresenterTopPageDataQueryVariables>

--- a/src/containers/presenter/appears.tsx
+++ b/src/containers/presenter/appears.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { GetPresenterAppearsPageDataQuery } from './__generated__/appears';
 import { PresenterPivotFragment } from './__generated__/pivot';

--- a/src/containers/presenter/detail.tsx
+++ b/src/containers/presenter/detail.tsx
@@ -25,6 +25,7 @@ import { useIsPersonFavorited } from '~lib/api/useIsPersonFavorited';
 import { BaseColors } from '~lib/constants';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import ForwardIcon from '../../../public/img/icons/icon-forward-light.svg';
 import { GetPresenterDetailPageDataQuery } from './__generated__/detail';

--- a/src/containers/presenter/list/__generated__/all.ts
+++ b/src/containers/presenter/list/__generated__/all.ts
@@ -66,7 +66,8 @@ export const useInfiniteGetPresenterListAllPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterListAllPageData<T>(
 	variables: ExactAlt<T, GetPresenterListAllPageDataQueryVariables>

--- a/src/containers/presenter/list/__generated__/letter.ts
+++ b/src/containers/presenter/list/__generated__/letter.ts
@@ -57,7 +57,8 @@ export const useInfiniteGetPresenterListLetterPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterListLetterPageData<T>(
 	variables: ExactAlt<T, GetPresenterListLetterPageDataQueryVariables>

--- a/src/containers/presenter/list/__generated__/list.ts
+++ b/src/containers/presenter/list/__generated__/list.ts
@@ -57,7 +57,8 @@ export const useInfiniteGetPersonListLetterCountsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPersonListLetterCounts<T>(
 	variables: ExactAlt<T, GetPersonListLetterCountsQueryVariables>

--- a/src/containers/presenter/recordings.tsx
+++ b/src/containers/presenter/recordings.tsx
@@ -11,6 +11,7 @@ import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import { PresenterPivotFragment } from './__generated__/pivot';
 import { GetPresenterRecordingsPageDataQuery } from './__generated__/recordings';

--- a/src/containers/presenter/sequences.tsx
+++ b/src/containers/presenter/sequences.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { PresenterPivotFragment } from './__generated__/pivot';
 import { GetPresenterSequencesPageDataQuery } from './__generated__/sequences';

--- a/src/containers/presenter/top.tsx
+++ b/src/containers/presenter/top.tsx
@@ -6,6 +6,7 @@ import withFailStates from '~components/HOCs/withFailStates';
 import CardRecording from '~components/molecules/card/recording';
 import CardGroup from '~components/molecules/cardGroup';
 import { BaseColors } from '~lib/constants';
+import { Must } from '~src/types/types';
 
 import { PresenterPivotFragment } from './__generated__/pivot';
 import { GetPresenterTopPageDataQuery } from './__generated__/top';

--- a/src/containers/release/__generated__/detail.ts
+++ b/src/containers/release/__generated__/detail.ts
@@ -123,7 +123,8 @@ export const useSubmitMediaReleaseFormMutation = <
       (variables?: SubmitMediaReleaseFormMutationVariables) => graphqlFetcher<SubmitMediaReleaseFormMutation, SubmitMediaReleaseFormMutationVariables>(SubmitMediaReleaseFormDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getMediaReleaseFormsPageData<T>(
 	variables: ExactAlt<T, GetMediaReleaseFormsPageDataQueryVariables>

--- a/src/containers/release/detail.tsx
+++ b/src/containers/release/detail.tsx
@@ -9,6 +9,7 @@ import Button from '~components/molecules/button';
 import ContentWidthLimiter from '~components/molecules/contentWidthLimiter';
 import Input from '~components/molecules/form/input';
 import Textarea from '~components/molecules/form/textarea';
+import { Must } from '~src/types/types';
 
 import {
 	GetMediaReleaseFormsPageDataQuery,

--- a/src/containers/search/__generated__/collections.ts
+++ b/src/containers/search/__generated__/collections.ts
@@ -53,7 +53,8 @@ export const useInfiniteGetSearchResultsCollectionsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchResultsCollections<T>(
 	variables: ExactAlt<T, GetSearchResultsCollectionsQueryVariables>

--- a/src/containers/search/__generated__/persons.ts
+++ b/src/containers/search/__generated__/persons.ts
@@ -53,7 +53,8 @@ export const useInfiniteGetSearchResultsPersonsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchResultsPersons<T>(
 	variables: ExactAlt<T, GetSearchResultsPersonsQueryVariables>

--- a/src/containers/search/__generated__/sequences.ts
+++ b/src/containers/search/__generated__/sequences.ts
@@ -55,7 +55,8 @@ export const useInfiniteGetSearchResultsSequencesQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchResultsSequences<T>(
 	variables: ExactAlt<T, GetSearchResultsSequencesQueryVariables>

--- a/src/containers/search/__generated__/sponsors.ts
+++ b/src/containers/search/__generated__/sponsors.ts
@@ -53,7 +53,8 @@ export const useInfiniteGetSearchResultsSponsorsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchResultsSponsors<T>(
 	variables: ExactAlt<T, GetSearchResultsSponsorsQueryVariables>

--- a/src/containers/search/__generated__/teachings.ts
+++ b/src/containers/search/__generated__/teachings.ts
@@ -63,7 +63,8 @@ export const useInfiniteGetSearchResultsRecordingsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchResultsRecordings<T>(
 	variables: ExactAlt<T, GetSearchResultsRecordingsQueryVariables>

--- a/src/containers/series/__generated__/detail.ts
+++ b/src/containers/series/__generated__/detail.ts
@@ -155,7 +155,8 @@ export const useInfiniteGetSeriesDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSeriesDetailPageData<T>(
 	variables: ExactAlt<T, GetSeriesDetailPageDataQueryVariables>

--- a/src/containers/series/__generated__/list.ts
+++ b/src/containers/series/__generated__/list.ts
@@ -102,7 +102,8 @@ export const useInfiniteGetSeriesListPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSeriesListPageData<T>(
 	variables: ExactAlt<T, GetSeriesListPageDataQueryVariables>

--- a/src/containers/sermon/__generated__/detail.ts
+++ b/src/containers/sermon/__generated__/detail.ts
@@ -107,7 +107,8 @@ export const useInfiniteGetSermonDetailStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSermonDetailData<T>(
 	variables: ExactAlt<T, GetSermonDetailDataQueryVariables>

--- a/src/containers/sermon/__generated__/list.ts
+++ b/src/containers/sermon/__generated__/list.ts
@@ -161,7 +161,8 @@ export const useInfiniteGetSermonListPagePathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSermonListPageData<T>(
 	variables: ExactAlt<T, GetSermonListPageDataQueryVariables>

--- a/src/containers/sermon/__generated__/trending.ts
+++ b/src/containers/sermon/__generated__/trending.ts
@@ -65,7 +65,8 @@ export const useInfiniteGetTrendingTeachingsPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getTrendingTeachingsPageData<T>(
 	variables: ExactAlt<T, GetTrendingTeachingsPageDataQueryVariables>

--- a/src/containers/sermon/embed.tsx
+++ b/src/containers/sermon/embed.tsx
@@ -9,6 +9,7 @@ import Player from '~components/molecules/player';
 import AndMiniplayer from '~components/templates/andMiniplayer';
 import { getRecordingTypeTheme } from '~lib/getRecordingTheme';
 import { getSequenceTypeTheme } from '~lib/getSequenceType';
+import { Must } from '~src/types/types';
 
 import Logo from '../../../public/img/logo-small.svg';
 import { GetSermonDetailDataQuery } from './__generated__/detail';

--- a/src/containers/sermon/trending.tsx
+++ b/src/containers/sermon/trending.tsx
@@ -9,6 +9,7 @@ import CardGroup from '~components/molecules/cardGroup';
 import RecordingHasVideoFilter from '~components/molecules/recordingHasVideoFilter';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import { GetTrendingTeachingsPageDataQuery } from './__generated__/trending';
 import styles from './trending.module.scss';

--- a/src/containers/song/__generated__/detail.ts
+++ b/src/containers/song/__generated__/detail.ts
@@ -106,7 +106,8 @@ export const useInfiniteGetSongDetailStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSongDetailData<T>(
 	variables: ExactAlt<T, GetSongDetailDataQueryVariables>

--- a/src/containers/song/albums/__generated__/detail.ts
+++ b/src/containers/song/albums/__generated__/detail.ts
@@ -152,7 +152,8 @@ export const useInfiniteGetSongAlbumsDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSongAlbumsDetailPageData<T>(
 	variables: ExactAlt<T, GetSongAlbumsDetailPageDataQueryVariables>

--- a/src/containers/song/albums/__generated__/list.ts
+++ b/src/containers/song/albums/__generated__/list.ts
@@ -85,7 +85,8 @@ export const useInfiniteGetSongAlbumsListPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSongAlbumsListPageData<T>(
 	variables: ExactAlt<T, GetSongAlbumsListPageDataQueryVariables>

--- a/src/containers/song/books/__generated__/detail.ts
+++ b/src/containers/song/books/__generated__/detail.ts
@@ -63,7 +63,8 @@ export const useInfiniteGetSongBooksDetailPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSongBooksDetailPageData<T>(
 	variables: ExactAlt<T, GetSongBooksDetailPageDataQueryVariables>

--- a/src/containers/song/books/__generated__/track.ts
+++ b/src/containers/song/books/__generated__/track.ts
@@ -74,7 +74,8 @@ export const useInfiniteGetBookSongDetailDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getBookSongDetailData<T>(
 	variables: ExactAlt<T, GetBookSongDetailDataQueryVariables>

--- a/src/containers/song/books/track.tsx
+++ b/src/containers/song/books/track.tsx
@@ -4,6 +4,7 @@ import withFailStates from '~components/HOCs/withFailStates';
 import { Recording } from '~components/organisms/recording';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import { GetBookSongDetailDataQuery } from './__generated__/track';
 

--- a/src/containers/sponsor/__generated__/conferences.ts
+++ b/src/containers/sponsor/__generated__/conferences.ts
@@ -108,7 +108,8 @@ export const useInfiniteGetSponsorConferencesPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorConferencesPageData<T>(
 	variables: ExactAlt<T, GetSponsorConferencesPageDataQueryVariables>

--- a/src/containers/sponsor/__generated__/detail.ts
+++ b/src/containers/sponsor/__generated__/detail.ts
@@ -149,7 +149,8 @@ export const useInfiniteGetSponsorDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorDetailPageData<T>(
 	variables: ExactAlt<T, GetSponsorDetailPageDataQueryVariables>

--- a/src/containers/sponsor/__generated__/series.ts
+++ b/src/containers/sponsor/__generated__/series.ts
@@ -110,7 +110,8 @@ export const useInfiniteGetSponsorSeriesPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorSeriesPageData<T>(
 	variables: ExactAlt<T, GetSponsorSeriesPageDataQueryVariables>

--- a/src/containers/sponsor/__generated__/teachings.ts
+++ b/src/containers/sponsor/__generated__/teachings.ts
@@ -165,7 +165,8 @@ export const useInfiniteGetSponsorTeachingsPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorTeachingsPageData<T>(
 	variables: ExactAlt<T, GetSponsorTeachingsPageDataQueryVariables>

--- a/src/containers/sponsor/conferences.tsx
+++ b/src/containers/sponsor/conferences.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { GetSponsorConferencesPageDataQuery } from './__generated__/conferences';
 import { SponsorPivotFragment } from './__generated__/pivot';

--- a/src/containers/sponsor/detail.tsx
+++ b/src/containers/sponsor/detail.tsx
@@ -25,6 +25,7 @@ import { useIsSponsorFavorited } from '~lib/api/useIsSponsorFavorited';
 import { BaseColors } from '~lib/constants';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import ForwardIcon from '../../../public/img/icons/icon-forward-light.svg';
 import { GetSponsorDetailPageDataQuery } from './__generated__/detail';

--- a/src/containers/sponsor/list/__generated__/all.ts
+++ b/src/containers/sponsor/list/__generated__/all.ts
@@ -57,7 +57,8 @@ export const useInfiniteGetSponsorListAllPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorListAllPageData<T>(
 	variables: ExactAlt<T, GetSponsorListAllPageDataQueryVariables>

--- a/src/containers/sponsor/list/__generated__/letter.ts
+++ b/src/containers/sponsor/list/__generated__/letter.ts
@@ -57,7 +57,8 @@ export const useInfiniteGetSponsorListLetterPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorListLetterPageData<T>(
 	variables: ExactAlt<T, GetSponsorListLetterPageDataQueryVariables>

--- a/src/containers/sponsor/list/__generated__/list.ts
+++ b/src/containers/sponsor/list/__generated__/list.ts
@@ -55,7 +55,8 @@ export const useInfiniteGetSponsorListLetterCountsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorListLetterCounts<T>(
 	variables: ExactAlt<T, GetSponsorListLetterCountsQueryVariables>

--- a/src/containers/sponsor/series.tsx
+++ b/src/containers/sponsor/series.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { SponsorPivotFragment } from './__generated__/pivot';
 import { GetSponsorSeriesPageDataQuery } from './__generated__/series';

--- a/src/containers/sponsor/teachings.tsx
+++ b/src/containers/sponsor/teachings.tsx
@@ -11,6 +11,7 @@ import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import { SponsorPivotFragment } from './__generated__/pivot';
 import { GetSponsorTeachingsPageDataQuery } from './__generated__/teachings';

--- a/src/containers/story/__generated__/detail.ts
+++ b/src/containers/story/__generated__/detail.ts
@@ -106,7 +106,8 @@ export const useInfiniteGetStoryDetailStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getStoryDetailData<T>(
 	variables: ExactAlt<T, GetStoryDetailDataQueryVariables>

--- a/src/containers/story/albums/__generated__/detail.ts
+++ b/src/containers/story/albums/__generated__/detail.ts
@@ -162,7 +162,8 @@ export const useInfiniteGetStoryAlbumDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getStoryAlbumDetailPageData<T>(
 	variables: ExactAlt<T, GetStoryAlbumDetailPageDataQueryVariables>

--- a/src/containers/story/albums/__generated__/list.ts
+++ b/src/containers/story/albums/__generated__/list.ts
@@ -97,7 +97,8 @@ export const useInfiniteGetStoriesAlbumsPathDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getStoriesAlbumsPageData<T>(
 	variables: ExactAlt<T, GetStoriesAlbumsPageDataQueryVariables>

--- a/src/lib/api/__generated__/bibleContent.ts
+++ b/src/lib/api/__generated__/bibleContent.ts
@@ -50,7 +50,8 @@ export const useInfiniteGetBibleBookContentQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getBibleBookContent<T>(
 	variables: ExactAlt<T, GetBibleBookContentQueryVariables>

--- a/src/lib/api/__generated__/collectionFavorite.ts
+++ b/src/lib/api/__generated__/collectionFavorite.ts
@@ -26,7 +26,8 @@ export const useCollectionFavoriteMutation = <
       (variables?: CollectionFavoriteMutationVariables) => graphqlFetcher<CollectionFavoriteMutation, CollectionFavoriteMutationVariables>(CollectionFavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function collectionFavorite<T>(
 	variables: ExactAlt<T, CollectionFavoriteMutationVariables>

--- a/src/lib/api/__generated__/collectionIsFavorited.ts
+++ b/src/lib/api/__generated__/collectionIsFavorited.ts
@@ -45,7 +45,8 @@ export const useInfiniteCollectionIsFavoritedQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function collectionIsFavorited<T>(
 	variables: ExactAlt<T, CollectionIsFavoritedQueryVariables>

--- a/src/lib/api/__generated__/collectionUnfavorite.ts
+++ b/src/lib/api/__generated__/collectionUnfavorite.ts
@@ -26,7 +26,8 @@ export const useCollectionUnfavoriteMutation = <
       (variables?: CollectionUnfavoriteMutationVariables) => graphqlFetcher<CollectionUnfavoriteMutation, CollectionUnfavoriteMutationVariables>(CollectionUnfavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function collectionUnfavorite<T>(
 	variables: ExactAlt<T, CollectionUnfavoriteMutationVariables>

--- a/src/lib/api/__generated__/login.ts
+++ b/src/lib/api/__generated__/login.ts
@@ -32,7 +32,8 @@ export const useLoginMutation = <
       (variables?: LoginMutationVariables) => graphqlFetcher<LoginMutation, LoginMutationVariables>(LoginDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function login<T>(
 	variables: ExactAlt<T, LoginMutationVariables>

--- a/src/lib/api/__generated__/personFavorite.ts
+++ b/src/lib/api/__generated__/personFavorite.ts
@@ -26,7 +26,8 @@ export const usePersonFavoriteMutation = <
       (variables?: PersonFavoriteMutationVariables) => graphqlFetcher<PersonFavoriteMutation, PersonFavoriteMutationVariables>(PersonFavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function personFavorite<T>(
 	variables: ExactAlt<T, PersonFavoriteMutationVariables>

--- a/src/lib/api/__generated__/personIsFavorited.ts
+++ b/src/lib/api/__generated__/personIsFavorited.ts
@@ -44,7 +44,8 @@ export const useInfinitePersonIsFavoritedQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function personIsFavorited<T>(
 	variables: ExactAlt<T, PersonIsFavoritedQueryVariables>

--- a/src/lib/api/__generated__/personUnfavorite.ts
+++ b/src/lib/api/__generated__/personUnfavorite.ts
@@ -26,7 +26,8 @@ export const usePersonUnfavoriteMutation = <
       (variables?: PersonUnfavoriteMutationVariables) => graphqlFetcher<PersonUnfavoriteMutation, PersonUnfavoriteMutationVariables>(PersonUnfavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function personUnfavorite<T>(
 	variables: ExactAlt<T, PersonUnfavoriteMutationVariables>

--- a/src/lib/api/__generated__/recordingFavorite.ts
+++ b/src/lib/api/__generated__/recordingFavorite.ts
@@ -26,7 +26,8 @@ export const useRecordingFavoriteMutation = <
       (variables?: RecordingFavoriteMutationVariables) => graphqlFetcher<RecordingFavoriteMutation, RecordingFavoriteMutationVariables>(RecordingFavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function recordingFavorite<T>(
 	variables: ExactAlt<T, RecordingFavoriteMutationVariables>

--- a/src/lib/api/__generated__/recordingIsFavorited.ts
+++ b/src/lib/api/__generated__/recordingIsFavorited.ts
@@ -44,7 +44,8 @@ export const useInfiniteRecordingIsFavoritedQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function recordingIsFavorited<T>(
 	variables: ExactAlt<T, RecordingIsFavoritedQueryVariables>

--- a/src/lib/api/__generated__/recordingUnfavorite.ts
+++ b/src/lib/api/__generated__/recordingUnfavorite.ts
@@ -26,7 +26,8 @@ export const useRecordingUnfavoriteMutation = <
       (variables?: RecordingUnfavoriteMutationVariables) => graphqlFetcher<RecordingUnfavoriteMutation, RecordingUnfavoriteMutationVariables>(RecordingUnfavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function recordingUnfavorite<T>(
 	variables: ExactAlt<T, RecordingUnfavoriteMutationVariables>

--- a/src/lib/api/__generated__/sequenceFavorite.ts
+++ b/src/lib/api/__generated__/sequenceFavorite.ts
@@ -26,7 +26,8 @@ export const useSequenceFavoriteMutation = <
       (variables?: SequenceFavoriteMutationVariables) => graphqlFetcher<SequenceFavoriteMutation, SequenceFavoriteMutationVariables>(SequenceFavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sequenceFavorite<T>(
 	variables: ExactAlt<T, SequenceFavoriteMutationVariables>

--- a/src/lib/api/__generated__/sequenceIsFavorited.ts
+++ b/src/lib/api/__generated__/sequenceIsFavorited.ts
@@ -50,7 +50,8 @@ export const useInfiniteSequenceIsFavoritedQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sequenceIsFavorited<T>(
 	variables: ExactAlt<T, SequenceIsFavoritedQueryVariables>

--- a/src/lib/api/__generated__/sequenceUnfavorite.ts
+++ b/src/lib/api/__generated__/sequenceUnfavorite.ts
@@ -26,7 +26,8 @@ export const useSequenceUnfavoriteMutation = <
       (variables?: SequenceUnfavoriteMutationVariables) => graphqlFetcher<SequenceUnfavoriteMutation, SequenceUnfavoriteMutationVariables>(SequenceUnfavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sequenceUnfavorite<T>(
 	variables: ExactAlt<T, SequenceUnfavoriteMutationVariables>

--- a/src/lib/api/__generated__/sponsorFavorite.ts
+++ b/src/lib/api/__generated__/sponsorFavorite.ts
@@ -26,7 +26,8 @@ export const useSponsorFavoriteMutation = <
       (variables?: SponsorFavoriteMutationVariables) => graphqlFetcher<SponsorFavoriteMutation, SponsorFavoriteMutationVariables>(SponsorFavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sponsorFavorite<T>(
 	variables: ExactAlt<T, SponsorFavoriteMutationVariables>

--- a/src/lib/api/__generated__/sponsorIsFavorited.ts
+++ b/src/lib/api/__generated__/sponsorIsFavorited.ts
@@ -44,7 +44,8 @@ export const useInfiniteSponsorIsFavoritedQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sponsorIsFavorited<T>(
 	variables: ExactAlt<T, SponsorIsFavoritedQueryVariables>

--- a/src/lib/api/__generated__/sponsorUnfavorite.ts
+++ b/src/lib/api/__generated__/sponsorUnfavorite.ts
@@ -26,7 +26,8 @@ export const useSponsorUnfavoriteMutation = <
       (variables?: SponsorUnfavoriteMutationVariables) => graphqlFetcher<SponsorUnfavoriteMutation, SponsorUnfavoriteMutationVariables>(SponsorUnfavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sponsorUnfavorite<T>(
 	variables: ExactAlt<T, SponsorUnfavoriteMutationVariables>

--- a/src/lib/test/buildLoader.ts
+++ b/src/lib/test/buildLoader.ts
@@ -1,8 +1,8 @@
 import { when } from 'jest-when';
 import defaultsDeep from 'lodash/defaultsDeep';
-import { PartialDeep } from 'type-fest';
 
 import * as api from '~lib/api/fetchApi';
+import { PartialDeepRecursive } from '~src/types/types';
 
 import {
 	createControlledPromise,
@@ -16,14 +16,7 @@ type Options = {
 	variables?: Record<string, unknown>;
 };
 
-type PartialData<T> =
-	| PartialDeep<
-			T,
-			{
-				recurseIntoArrays: true;
-			}
-	  >
-	| Record<string, never>;
+type PartialData<T> = PartialDeepRecursive<T> | Record<string, never>;
 
 type Loader<T> = (
 	data?: PartialData<T>,

--- a/src/lib/test/buildPageRenderer.tsx
+++ b/src/lib/test/buildPageRenderer.tsx
@@ -1,16 +1,12 @@
 import { __mockedRouter } from 'next/router';
 import { ComponentType } from 'react';
-import { PartialDeep } from 'type-fest';
+
+import { PartialDeepRecursive } from '~src/types/types';
 
 import { buildRenderer, RendererResult } from './buildRenderer';
 
 type PageRendererOptions<T> = {
-	props?: PartialDeep<
-		T,
-		{
-			recurseIntoArrays: true;
-		}
-	>;
+	props?: PartialDeepRecursive<T>;
 };
 
 export type PageRenderer<T> = (
@@ -25,7 +21,5 @@ export function buildPageRenderer<T extends Record<string, unknown>>(
 ): PageRenderer<T> {
 	const { getProps } = options;
 	const r = buildRenderer(Page);
-	return async () => {
-		return r({ props: await getProps(__mockedRouter.query) });
-	};
+	return async () => r({ props: await getProps(__mockedRouter.query) });
 }

--- a/src/lib/test/buildPageRenderer.tsx
+++ b/src/lib/test/buildPageRenderer.tsx
@@ -1,0 +1,32 @@
+import { QueryClient } from '@tanstack/react-query';
+import { RenderResult } from '@testing-library/react';
+import { __mockedRouter } from 'next/router';
+import { ComponentType } from 'react';
+
+import { buildRenderer } from './buildRenderer';
+
+// TODO: Only accept props if getProps not provided
+// TODO: Only accept params if getProps provided
+type PageRendererOptions = {
+	props?: any; // TODO: restrict to props component actually accepts
+};
+
+export type PageRenderer = (
+	options?: PageRendererOptions
+) => Promise<RenderResult & { queryClient: QueryClient }>;
+
+export function buildPageRenderer<
+	C extends ComponentType<any>,
+	F extends (params: any) => Promise<any>
+>(
+	Page: C,
+	options: {
+		getProps: F;
+	}
+): PageRenderer {
+	const { getProps } = options;
+	const r = buildRenderer(Page);
+	return async (): Promise<RenderResult & { queryClient: QueryClient }> => {
+		return r({ props: await getProps(__mockedRouter.query) });
+	};
+}

--- a/src/lib/test/buildRenderer.tsx
+++ b/src/lib/test/buildRenderer.tsx
@@ -2,19 +2,17 @@ import { QueryClient } from '@tanstack/react-query';
 import { RenderResult } from '@testing-library/react';
 import { __mockedRouter } from 'next/router';
 import React, { ComponentType } from 'react';
-import { PartialDeep } from 'type-fest';
 
 import renderWithProviders from '~lib/test/renderWithProviders';
+import { PartialDeepRecursive } from '~src/types/types';
 
 type RendererOptions<T> = {
-	props?: PartialDeep<T, { recurseIntoArrays: true }>;
+	props?: PartialDeepRecursive<T>;
 };
 
 export type RendererResult<T> = Omit<RenderResult, 'rerender'> & {
 	queryClient: QueryClient;
-	rerender: (
-		rerenderProps?: PartialDeep<T, { recurseIntoArrays: true }>
-	) => void;
+	rerender: (rerenderProps?: PartialDeepRecursive<T>) => void;
 };
 
 export type Renderer<T> = (
@@ -24,7 +22,7 @@ export type Renderer<T> = (
 export function buildRenderer<T extends Record<string, any>>(
 	Component: ComponentType<T>,
 	options: {
-		defaultProps?: PartialDeep<T, { recurseIntoArrays: true }>;
+		defaultProps?: PartialDeepRecursive<T>;
 	} = {}
 ): Renderer<T> {
 	const { defaultProps = {} } = options;
@@ -35,11 +33,9 @@ export function buildRenderer<T extends Record<string, any>>(
 		const r = await renderWithProviders(<Component {...p} />);
 		return {
 			...r,
-			rerender: (
-				rerenderProps?: PartialDeep<T, { recurseIntoArrays: true }>
-			) => {
+			rerender: (rerenderProps?: PartialDeepRecursive<T>) => {
 				const rp = { ...p, ...(rerenderProps || {}) };
-				return r.rerender(<Component {...rp} />);
+				r.rerender(<Component {...rp} />);
 			},
 		};
 	};

--- a/src/lib/test/buildServerRenderer.ts
+++ b/src/lib/test/buildServerRenderer.ts
@@ -1,19 +1,19 @@
 import { GetServerSidePropsResult } from 'next';
 import { ComponentType } from 'react';
 
-import { buildRenderer, Renderer } from '~lib/test/buildRenderer';
+import { Renderer } from '~lib/test/buildRenderer';
 
-export function buildServerRenderer<
-	C extends ComponentType<any>,
-	F extends (context: any) => Promise<GetServerSidePropsResult<any>>
->(Component: C, getServerSideProps: F): Renderer {
+import { buildPageRenderer } from './buildPageRenderer';
+
+export function buildServerRenderer<T>(
+	Component: ComponentType<T>,
+	getServerSideProps: (context: any) => Promise<GetServerSidePropsResult<any>>
+): Renderer<T> {
 	const getProps = async (p: any) => {
-		const result = await getServerSideProps({ params: p, query: p } as any);
-		if (!('props' in result)) {
-			throw new Error('Failed to get server props');
-		}
-		return result.props;
+		const r = await getServerSideProps({ params: p, query: p } as any);
+		if (!('props' in r)) throw new Error('Failed to get server props');
+		return r.props;
 	};
 
-	return buildRenderer(Component, { getProps });
+	return buildPageRenderer(Component, { getProps });
 }

--- a/src/lib/test/buildServerRenderer.ts
+++ b/src/lib/test/buildServerRenderer.ts
@@ -1,14 +1,12 @@
 import { GetServerSidePropsResult } from 'next';
 import { ComponentType } from 'react';
 
-import { Renderer } from '~lib/test/buildRenderer';
+import { buildPageRenderer, PageRenderer } from './buildPageRenderer';
 
-import { buildPageRenderer } from './buildPageRenderer';
-
-export function buildServerRenderer<T>(
+export function buildServerRenderer<T extends Record<string, unknown>>(
 	Component: ComponentType<T>,
 	getServerSideProps: (context: any) => Promise<GetServerSidePropsResult<any>>
-): Renderer<T> {
+): PageRenderer<T> {
 	const getProps = async (p: any) => {
 		const r = await getServerSideProps({ params: p, query: p } as any);
 		if (!('props' in r)) throw new Error('Failed to get server props');

--- a/src/lib/test/buildStaticRenderer.ts
+++ b/src/lib/test/buildStaticRenderer.ts
@@ -1,14 +1,12 @@
 import { GetStaticProps } from 'next';
 import { ComponentType } from 'react';
 
-import { Renderer } from '~lib/test/buildRenderer';
-
-import { buildPageRenderer } from './buildPageRenderer';
+import { buildPageRenderer, PageRenderer } from './buildPageRenderer';
 
 export function buildStaticRenderer<T extends Record<string, any>>(
 	Component: ComponentType<T>,
 	getStaticProps: GetStaticProps<any, any>
-): Renderer<T> {
+): PageRenderer<T> {
 	const getProps = async (p: any) =>
 		((await getStaticProps({ params: p })) as any).props;
 

--- a/src/lib/test/buildStaticRenderer.ts
+++ b/src/lib/test/buildStaticRenderer.ts
@@ -1,14 +1,16 @@
 import { GetStaticProps } from 'next';
 import { ComponentType } from 'react';
 
-import { buildRenderer, Renderer } from '~lib/test/buildRenderer';
+import { Renderer } from '~lib/test/buildRenderer';
 
-export function buildStaticRenderer<
-	C extends ComponentType<any>,
-	F extends GetStaticProps<any, any>
->(Component: C, getStaticProps: F): Renderer {
+import { buildPageRenderer } from './buildPageRenderer';
+
+export function buildStaticRenderer<T extends Record<string, any>>(
+	Component: ComponentType<T>,
+	getStaticProps: GetStaticProps<any, any>
+): Renderer<T> {
 	const getProps = async (p: any) =>
 		((await getStaticProps({ params: p })) as any).props;
 
-	return buildRenderer(Component, { getProps });
+	return buildPageRenderer(Component, { getProps });
 }

--- a/src/lib/test/renderWithProviders.tsx
+++ b/src/lib/test/renderWithProviders.tsx
@@ -7,24 +7,35 @@ import { __awaitIntlMessages } from '~lib/getIntlMessages';
 
 import makeQueryClient from '../makeQueryClient';
 
+function withProviders(ui: React.ReactElement, client: QueryClient) {
+	const WithIntl = withIntl(() => ui);
+
+	return function WithProviders() {
+		return (
+			<QueryClientProvider client={client}>
+				<WithIntl />
+			</QueryClientProvider>
+		);
+	};
+}
+
 export default async function renderWithProviders(
 	ui: React.ReactElement,
 	renderOptions?: RenderOptions
 ): Promise<RenderResult & { queryClient: QueryClient }> {
 	const queryClient = makeQueryClient();
-	const WithIntl = withIntl(() => ui);
+	const WithProviders = withProviders(ui, queryClient);
 
-	const result = render(
-		<QueryClientProvider client={queryClient}>
-			<WithIntl />
-		</QueryClientProvider>,
-		renderOptions
-	);
+	const result = render(<WithProviders />, renderOptions);
 
 	await __awaitIntlMessages();
 
 	return {
 		...result,
 		queryClient,
+		rerender: (rerenderUi: React.ReactElement) => {
+			const WithProviders = withProviders(rerenderUi, queryClient);
+			return result.rerender(<WithProviders />);
+		},
 	};
 }

--- a/src/lib/test/renderWithProviders.tsx
+++ b/src/lib/test/renderWithProviders.tsx
@@ -35,7 +35,7 @@ export default async function renderWithProviders(
 		queryClient,
 		rerender: (rerenderUi: React.ReactElement) => {
 			const WithProviders = withProviders(rerenderUi, queryClient);
-			return result.rerender(<WithProviders />);
+			result.rerender(<WithProviders />);
 		},
 	};
 }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,3 +1,5 @@
+import { PartialDeep } from 'type-fest';
+
 type ExactAlt<T, Shape> = T extends Shape
 	? Exclude<keyof T, keyof Shape> extends never
 		? T
@@ -8,3 +10,10 @@ type ExactAlt<T, Shape> = T extends Shape
 type Must<T> = {
 	[P in keyof T]-?: NonNullable<T[P]>;
 };
+
+type PartialDeepRecursive<T> = PartialDeep<
+	T,
+	{
+		recurseIntoArrays: true;
+	}
+>;

--- a/testSetup.ts
+++ b/testSetup.ts
@@ -14,6 +14,39 @@ jest.mock('~lib/getIntlMessages');
 jest.mock('~lib/makeQueryClient');
 jest.mock('~lib/swiper');
 
+interface CustomMatchers<R = unknown> {
+	toAppearBefore: (argument: HTMLElement) => R;
+}
+
+declare global {
+	/* eslint-disable */
+	// https://jestjs.io/docs/26.x/expect#expectextendmatchers
+	namespace jest {
+		interface Expect extends CustomMatchers {}
+		interface Matchers<R> extends CustomMatchers<R> {}
+		interface InverseAsymmetricMatchers extends CustomMatchers {}
+	}
+	/* eslint-enable */
+}
+
+expect.extend({
+	toAppearBefore(received: HTMLElement, argument: HTMLElement) {
+		const pass =
+			received.compareDocumentPosition(argument) &
+			Node.DOCUMENT_POSITION_FOLLOWING;
+
+		return pass
+			? {
+					message: () => `expected ${received} not to be before ${argument}`,
+					pass: true,
+			  }
+			: {
+					message: () => `expected ${received} to be before ${argument}`,
+					pass: false,
+			  };
+	},
+});
+
 // WORKAROUND: https://github.com/keppelen/react-facebook-login/issues/217#issuecomment-375652793
 beforeAll(() => {
 	const fbScript = document.createElement('script');

--- a/testSetup.ts
+++ b/testSetup.ts
@@ -31,19 +31,18 @@ declare global {
 
 expect.extend({
 	toAppearBefore(received: HTMLElement, argument: HTMLElement) {
-		const pass =
+		const pass = !!(
 			received.compareDocumentPosition(argument) &
-			Node.DOCUMENT_POSITION_FOLLOWING;
+			Node.DOCUMENT_POSITION_FOLLOWING
+		);
 
-		return pass
-			? {
-					message: () => `expected ${received} not to be before ${argument}`,
-					pass: true,
-			  }
-			: {
-					message: () => `expected ${received} to be before ${argument}`,
-					pass: false,
-			  };
+		return {
+			message: () =>
+				pass
+					? `expected ${received} not to be before ${argument}`
+					: `expected ${received} to be before ${argument}`,
+			pass,
+		};
 	},
 });
 


### PR DESCRIPTION
This PR:

- Updates search to reduce number of queries sent while the user is typing
- Updates search to only send queries for the active search tab
- Adds an empty state message when a user makes a search that returns no results

Branch name is a mistake. Jira story is actually AV 383.

Story: https://audioverse7.atlassian.net/jira/software/projects/AV/boards/3?selectedIssue=AV-383