### PR TITLE
Disable react scope rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
 		'plugin:testing-library/dom',
 		'plugin:jest-dom/recommended',
 		'plugin:@next/next/recommended',
+		'plugin:react/jsx-runtime',
 	],
 	root: true,
 	env: {

--- a/__mocks__/@material-ui/core/Slider.tsx
+++ b/__mocks__/@material-ui/core/Slider.tsx
@@ -1,5 +1,4 @@
 import type { SliderTypeMap } from '@material-ui/core';
-import React from 'react';
 
 // https://material-ui.com/components/slider/#range-slider
 // https://material-ui.com/api/slider/

--- a/__mocks__/masonic.tsx
+++ b/__mocks__/masonic.tsx
@@ -1,13 +1,12 @@
 import { RenderComponentProps } from 'masonic/src/use-masonry';
-import * as React from 'react';
-import { ReactNode } from 'react';
+import { ComponentType, ReactNode } from 'react';
 
 export function Masonry<T>({
 	items,
 	render: Render,
 }: {
 	items: T[];
-	render: React.ComponentType<RenderComponentProps<T>>;
+	render: ComponentType<RenderComponentProps<T>>;
 }): ReactNode {
 	return items.map((item, i) => (
 		<Render key={i} data={item} index={i} width={0} />

--- a/__mocks__/next/head.tsx
+++ b/__mocks__/next/head.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function Head({ children }: { children: JSX.Element }): JSX.Element {
 	return <div data-testid="head">{children}</div>;
 }

--- a/__mocks__/next/image.tsx
+++ b/__mocks__/next/image.tsx
@@ -1,5 +1,4 @@
 import { ImageProps } from 'next/image';
-import React from 'react';
 
 function Image(p: ImageProps): JSX.Element {
 	/* eslint-disable @next/next/no-img-element */

--- a/__mocks__/next/script.tsx
+++ b/__mocks__/next/script.tsx
@@ -1,3 +1,1 @@
-import React from 'react';
-
 export default jest.fn(() => <div />);

--- a/graphql-codegen/graphql-plugin-getters.ts
+++ b/graphql-codegen/graphql-plugin-getters.ts
@@ -56,7 +56,7 @@ const plugin: CodegenPlugin = {
 
 		if (!result) return '';
 
-		return `import { fetchApi } from '~lib/api/fetchApi' \n${result}`;
+		return `import { fetchApi } from '~lib/api/fetchApi';\nimport { ExactAlt } from '~src/types/types';\n${result}`;
 	},
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
                 "sass": "^1.42.1",
                 "striptags": "^3.2.0",
                 "swiper": "^9.3.2",
+                "use-debounce": "^9.0.4",
                 "video.js": "^7.21.1"
             },
             "devDependencies": {
@@ -9632,9 +9633,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001506",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
-            "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw==",
+            "version": "1.0.30001508",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
+            "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -22593,6 +22594,17 @@
             "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
             "dev": true
         },
+        "node_modules/use-debounce": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-9.0.4.tgz",
+            "integrity": "sha512-6X8H/mikbrt0XE8e+JXRtZ8yYVvKkdYRfmIhWZYsP8rcNs9hk3APV8Ua2mFkKRLcJKVdnX2/Vwrmg2GWKUQEaQ==",
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
         "node_modules/use-sync-external-store": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -30669,9 +30681,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001506",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001506.tgz",
-            "integrity": "sha512-6XNEcpygZMCKaufIcgpQNZNf00GEqc7VQON+9Rd0K1bMYo8xhMZRAo5zpbnbMNizi4YNgIDAFrdykWsvY3H4Hw=="
+            "version": "1.0.30001508",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001508.tgz",
+            "integrity": "sha512-sdQZOJdmt3GJs1UMNpCCCyeuS2IEGLXnHyAo9yIO5JJDjbjoVRij4M1qep6P6gFpptD1PqIYgzM+gwJbOi92mw=="
         },
         "capital-case": {
             "version": "1.0.4",
@@ -40593,6 +40605,12 @@
             "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
             "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
             "dev": true
+        },
+        "use-debounce": {
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-9.0.4.tgz",
+            "integrity": "sha512-6X8H/mikbrt0XE8e+JXRtZ8yYVvKkdYRfmIhWZYsP8rcNs9hk3APV8Ua2mFkKRLcJKVdnX2/Vwrmg2GWKUQEaQ==",
+            "requires": {}
         },
         "use-sync-external-store": {
             "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "sass": "^1.42.1",
         "striptags": "^3.2.0",
         "swiper": "^9.3.2",
+        "use-debounce": "^9.0.4",
         "video.js": "^7.21.1"
     },
     "devDependencies": {

--- a/public/compiled-lang/en.json
+++ b/public/compiled-lang/en.json
@@ -4603,6 +4603,18 @@
       "value": "See All Matching Conferences"
     }
   ],
+  "search__emptyStateMessage": [
+    {
+      "type": 0,
+      "value": "Try searching for something else"
+    }
+  ],
+  "search__emptyStateTitle": [
+    {
+      "type": 0,
+      "value": "No results found"
+    }
+  ],
   "search__musicHeading": [
     {
       "type": 0,

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -2196,6 +2196,12 @@
   "search__conferencesSeeAll": {
     "string": "See All Matching Conferences"
   },
+  "search__emptyStateMessage": {
+    "string": "Try searching for something else"
+  },
+  "search__emptyStateTitle": {
+    "string": "No results found"
+  },
   "search__musicHeading": {
     "string": "Music"
   },

--- a/src/components/HOCs/__generated__/withAuthGuard.ts
+++ b/src/components/HOCs/__generated__/withAuthGuard.ts
@@ -45,7 +45,8 @@ export const useInfiniteGetWithAuthGuardDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getWithAuthGuardData<T>(
 	variables: ExactAlt<T, GetWithAuthGuardDataQueryVariables>

--- a/src/components/HOCs/withAuthGuard.spec.tsx
+++ b/src/components/HOCs/withAuthGuard.spec.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { when } from 'jest-when';
 import Cookies from 'js-cookie';
 import { __loadRouter } from 'next/router';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 import withAuthGuard from '~components/HOCs/withAuthGuard';
 import { RegisterSocialDocument } from '~containers/account/__generated__/register';

--- a/src/components/HOCs/withAuthGuard.tsx
+++ b/src/components/HOCs/withAuthGuard.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Login from '~components/molecules/login';
 import { getCurrentRequest } from '~lib/api/storeRequest';
 import { getSessionToken } from '~lib/cookies';

--- a/src/components/HOCs/withFailStates.spec.tsx
+++ b/src/components/HOCs/withFailStates.spec.tsx
@@ -1,6 +1,5 @@
 import { render } from '@testing-library/react';
 import { useRouter } from 'next/router';
-import React from 'react';
 
 import withFailStates from '~components/HOCs/withFailStates';
 

--- a/src/components/HOCs/withFailStates.tsx
+++ b/src/components/HOCs/withFailStates.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import React from 'react';
 
 import LoadingCards from '~components/molecules/loadingCards';
 import NotFoundBase from '~components/organisms/notFound';

--- a/src/components/HOCs/withFailStates.tsx
+++ b/src/components/HOCs/withFailStates.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import LoadingCards from '~components/molecules/loadingCards';
 import NotFoundBase from '~components/organisms/notFound';
+import { Must } from '~src/types/types';
 
 type WithFailStateOptions<P> = {
 	useShould404?: (props: P) => boolean;

--- a/src/components/HOCs/withIntl.tsx
+++ b/src/components/HOCs/withIntl.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { IntlProvider, ResolvedIntlConfig } from 'react-intl';
 
 import getIntlMessages from '~lib/getIntlMessages';
@@ -14,7 +14,7 @@ const withIntl = <P extends Record<string, unknown>>(
 		const language = useLanguageRoute();
 		const [messages, setMessages] = useState<Messages>({});
 
-		React.useEffect(() => {
+		useEffect(() => {
 			getIntlMessages(language).then(setMessages);
 		}, [language]);
 

--- a/src/components/atoms/activeLink.tsx
+++ b/src/components/atoms/activeLink.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import Link, { LinkProps } from 'next/link';
 import { useRouter } from 'next/router';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 type ActiveLinkProps = LinkProps & {
 	children: ReactElement;

--- a/src/components/atoms/alert.tsx
+++ b/src/components/atoms/alert.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import styles from './alert.module.scss';
 

--- a/src/components/atoms/heading1.tsx
+++ b/src/components/atoms/heading1.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import baseStyles from './headingBase.module.scss';
 

--- a/src/components/atoms/heading2.tsx
+++ b/src/components/atoms/heading2.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import styles from './heading2.module.scss';
 import baseStyles from './headingBase.module.scss';

--- a/src/components/atoms/heading3.tsx
+++ b/src/components/atoms/heading3.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import styles from './heading3.module.scss';
 import baseStyles from './headingBase.module.scss';

--- a/src/components/atoms/heading6.tsx
+++ b/src/components/atoms/heading6.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import styles from './heading6.module.scss';
 import baseStyles from './headingBase.module.scss';

--- a/src/components/atoms/horizontalRule.tsx
+++ b/src/components/atoms/horizontalRule.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 
 import { BaseColors } from '~lib/constants';
 

--- a/src/components/atoms/infoBox.tsx
+++ b/src/components/atoms/infoBox.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import styles from './infoBox.module.scss';
 

--- a/src/components/atoms/inherentSizeImage.tsx
+++ b/src/components/atoms/inherentSizeImage.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 type Props = {
 	src: string;
 	title?: string;

--- a/src/components/atoms/lineHeading.tsx
+++ b/src/components/atoms/lineHeading.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import { BaseColors } from '~lib/constants';
 

--- a/src/components/atoms/progressBar.tsx
+++ b/src/components/atoms/progressBar.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import styles from './progressBar.module.scss';

--- a/src/components/atoms/roundImage.tsx
+++ b/src/components/atoms/roundImage.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import Image from 'next/legacy/image';
-import React from 'react';
 
 import styles from './roundImage.module.scss';
 

--- a/src/components/molecules/__generated__/helpWidget.ts
+++ b/src/components/molecules/__generated__/helpWidget.ts
@@ -58,7 +58,8 @@ export const useInfiniteGetHelpWidgetDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getHelpWidgetData<T>(
 	variables: ExactAlt<T, GetHelpWidgetDataQueryVariables>

--- a/src/components/molecules/__generated__/login.ts
+++ b/src/components/molecules/__generated__/login.ts
@@ -29,7 +29,8 @@ export const useLoginForgotPasswordMutation = <
       (variables?: LoginForgotPasswordMutationVariables) => graphqlFetcher<LoginForgotPasswordMutation, LoginForgotPasswordMutationVariables>(LoginForgotPasswordDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function loginForgotPassword<T>(
 	variables: ExactAlt<T, LoginForgotPasswordMutationVariables>

--- a/src/components/molecules/bibleVersionTypeLockup.tsx
+++ b/src/components/molecules/bibleVersionTypeLockup.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { BaseColors } from '~lib/constants';

--- a/src/components/molecules/button.tsx
+++ b/src/components/molecules/button.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import Link from 'next/link';
-import React, { MouseEvent } from 'react';
+import { MouseEvent } from 'react';
 
 import styles from './button.module.scss';
 
@@ -10,7 +10,7 @@ export type IButtonType =
 	| 'primaryInverse'
 	| 'secondary'
 	| 'secondaryInverse';
-// | 'tertiary' someday
+// | 'tertiary' TODO
 
 type Props = {
 	type: IButtonType;

--- a/src/components/molecules/buttonBack.tsx
+++ b/src/components/molecules/buttonBack.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Button, { IButtonType } from '~components/molecules/button';

--- a/src/components/molecules/buttonDownload.tsx
+++ b/src/components/molecules/buttonDownload.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading6 from '~components/atoms/heading6';

--- a/src/components/molecules/buttonFavorite.tsx
+++ b/src/components/molecules/buttonFavorite.tsx
@@ -1,4 +1,4 @@
-import React, { Ref } from 'react';
+import { forwardRef, Ref } from 'react';
 import { useIntl } from 'react-intl';
 
 import { BaseColors } from '~lib/constants';
@@ -18,55 +18,53 @@ type Props = {
 	ref?: Ref<HTMLButtonElement>;
 };
 
-const ButtonFavorite: React.VoidFunctionComponent<Props> = React.forwardRef(
-	function ButtonFavorite(
-		{ isFavorited, toggleFavorited, light, backgroundColor, className }: Props,
-		ref: Ref<HTMLButtonElement>
-	): JSX.Element {
-		const intl = useIntl();
-		const label = isFavorited
-			? intl.formatMessage({
-					id: 'RecordingFavorite__unfavorite',
-					defaultMessage: 'Unfavorite',
-					description: 'Recording unfavorite button label',
-			  })
-			: intl.formatMessage({
-					id: 'RecordingFavorite__favorite',
-					defaultMessage: 'Favorite',
-					description: 'Recording favorite button label',
-			  });
+const ButtonFavorite = forwardRef(function ButtonFavorite(
+	{ isFavorited, toggleFavorited, light, backgroundColor, className }: Props,
+	ref: Ref<HTMLButtonElement>
+): JSX.Element {
+	const intl = useIntl();
+	const label = isFavorited
+		? intl.formatMessage({
+				id: 'RecordingFavorite__unfavorite',
+				defaultMessage: 'Unfavorite',
+				description: 'Recording unfavorite button label',
+		  })
+		: intl.formatMessage({
+				id: 'RecordingFavorite__favorite',
+				defaultMessage: 'Favorite',
+				description: 'Recording favorite button label',
+		  });
 
-		const IconUnavorite = light ? IconLikeLight : IconLike;
-		const isDarkTheme = isBackgroundColorDark(backgroundColor);
+	const IconUnavorite = light ? IconLikeLight : IconLike;
+	const isDarkTheme = isBackgroundColorDark(backgroundColor);
 
-		const iconColor = isFavorited
-			? isDarkTheme
-				? BaseColors.SALMON
-				: BaseColors.RED
-			: isDarkTheme
-			? BaseColors.WHITE
-			: BaseColors.DARK;
+	const iconColor = isFavorited
+		? isDarkTheme
+			? BaseColors.SALMON
+			: BaseColors.RED
+		: isDarkTheme
+		? BaseColors.WHITE
+		: BaseColors.DARK;
 
-		return (
-			<IconButton
-				Icon={isFavorited ? IconLikeActive : IconUnavorite}
-				onClick={(e) => {
-					e.preventDefault();
-					e.stopPropagation();
-					toggleFavorited();
-				}}
-				color={iconColor}
-				{...{
-					backgroundColor,
-					className,
-					'aria-label': label,
-					'aria-pressed': isFavorited,
-					'data-testid': isFavorited ? 'unfavorite-icon' : 'favorite-icon',
-					ref,
-				}}
-			/>
-		);
-	}
-);
+	return (
+		<IconButton
+			Icon={isFavorited ? IconLikeActive : IconUnavorite}
+			onClick={(e) => {
+				e.preventDefault();
+				e.stopPropagation();
+				toggleFavorited();
+			}}
+			color={iconColor}
+			{...{
+				backgroundColor,
+				className,
+				'aria-label': label,
+				'aria-pressed': isFavorited,
+				'data-testid': isFavorited ? 'unfavorite-icon' : 'favorite-icon',
+				ref,
+			}}
+		/>
+	);
+});
 
 export default ButtonFavorite;

--- a/src/components/molecules/buttonGuest.tsx
+++ b/src/components/molecules/buttonGuest.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Button from '~components/molecules/button';

--- a/src/components/molecules/buttonNudge.tsx
+++ b/src/components/molecules/buttonNudge.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import { AndMiniplayerFragment } from '~components/templates/__generated__/andMiniplayer';

--- a/src/components/molecules/buttonPlay.tsx
+++ b/src/components/molecules/buttonPlay.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import { AndMiniplayerFragment } from '~components/templates/__generated__/andMiniplayer';

--- a/src/components/molecules/buttonPlayback.tsx
+++ b/src/components/molecules/buttonPlayback.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useIntl } from 'react-intl';
 
 import IconButton from '~components/molecules/iconButton';

--- a/src/components/molecules/buttonShare.tsx
+++ b/src/components/molecules/buttonShare.tsx
@@ -1,4 +1,4 @@
-import React, { MouseEvent, PropsWithChildren, useState } from 'react';
+import { MouseEvent, PropsWithChildren, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading6 from '~components/atoms/heading6';

--- a/src/components/molecules/buttonShareRecording.tsx
+++ b/src/components/molecules/buttonShareRecording.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading6 from '~components/atoms/heading6';

--- a/src/components/molecules/buttonSpeed.tsx
+++ b/src/components/molecules/buttonSpeed.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { AndMiniplayerFragment } from '~components/templates/__generated__/andMiniplayer';

--- a/src/components/molecules/card/audiobookTrack.tsx
+++ b/src/components/molecules/card/audiobookTrack.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TeaseRecording from '../teaseRecording';
 import { CardRecordingFragment } from './__generated__/recording';
 import CardWithTheme from './base/withTheme';

--- a/src/components/molecules/card/base/withCardTheme.tsx
+++ b/src/components/molecules/card/base/withCardTheme.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import styles from './withCardTheme.module.scss';
 

--- a/src/components/molecules/card/base/withTheme.tsx
+++ b/src/components/molecules/card/base/withTheme.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import Card from '..';
 import WithCardTheme, { ExtendedCardTheme } from './withCardTheme';

--- a/src/components/molecules/card/bibleBook.tsx
+++ b/src/components/molecules/card/bibleBook.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/bibleChapter.tsx
+++ b/src/components/molecules/card/bibleChapter.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TeaseRecording from '../teaseRecording';
 import { CardRecordingFragment } from './__generated__/recording';
 import CardWithTheme from './base/withTheme';

--- a/src/components/molecules/card/bibleVersion.tsx
+++ b/src/components/molecules/card/bibleVersion.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/collection.tsx
+++ b/src/components/molecules/card/collection.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import Image from 'next/legacy/image';
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/column.tsx
+++ b/src/components/molecules/card/column.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styles from './column.module.scss';
 
 interface CardColumnProps {

--- a/src/components/molecules/card/favorite.tsx
+++ b/src/components/molecules/card/favorite.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { CardFavoriteFragment } from './__generated__/favorite';
 import CardFavoriteEntity from './favoriteEntity';
 

--- a/src/components/molecules/card/favoriteEntity.tsx
+++ b/src/components/molecules/card/favoriteEntity.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { UnreachableCaseError } from '~lib/typeHelpers';
 
 import { CardFavoriteEntityFragment } from './__generated__/favoriteEntity';

--- a/src/components/molecules/card/hat/audiobook.tsx
+++ b/src/components/molecules/card/hat/audiobook.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/hat/bibleBook.tsx
+++ b/src/components/molecules/card/hat/bibleBook.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Heading2 from '~components/atoms/heading2';
 
 import HatIcon from '../../../../../public/img/icons/fa-book-light.svg';

--- a/src/components/molecules/card/hat/index.tsx
+++ b/src/components/molecules/card/hat/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { PropsWithChildren, useState } from 'react';
+import { PropsWithChildren, useState } from 'react';
 
 import Heading6 from '~components/atoms/heading6';
 

--- a/src/components/molecules/card/hat/sermon.tsx
+++ b/src/components/molecules/card/hat/sermon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/hat/song.tsx
+++ b/src/components/molecules/card/hat/song.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/hat/sponsor.tsx
+++ b/src/components/molecules/card/hat/sponsor.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/hat/story.tsx
+++ b/src/components/molecules/card/hat/story.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/index.tsx
+++ b/src/components/molecules/card/index.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import styles from '~components/molecules/card/index.module.scss';
 

--- a/src/components/molecules/card/inferred.tsx
+++ b/src/components/molecules/card/inferred.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SetRequired } from 'type-fest';
 
 import { CollectionContentType } from '~src/__generated__/graphql';

--- a/src/components/molecules/card/person.tsx
+++ b/src/components/molecules/card/person.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/playlist.tsx
+++ b/src/components/molecules/card/playlist.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/playlistItem.tsx
+++ b/src/components/molecules/card/playlistItem.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TeaseRecording from '../teaseRecording';
 import { CardRecordingFragment } from './__generated__/recording';
 import CardWithTheme from './base/withTheme';

--- a/src/components/molecules/card/post.tsx
+++ b/src/components/molecules/card/post.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import Image from 'next/legacy/image';
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/recording.tsx
+++ b/src/components/molecules/card/recording.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { UnreachableCaseError } from '~lib/typeHelpers';
 import { RecordingContentType } from '~src/__generated__/graphql';
 

--- a/src/components/molecules/card/recordingSequenceHat.tsx
+++ b/src/components/molecules/card/recordingSequenceHat.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { useIsSequenceFavorited } from '~lib/api/useIsSequenceFavorited';

--- a/src/components/molecules/card/recordingStack.tsx
+++ b/src/components/molecules/card/recordingStack.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { SequenceContentType } from '~src/__generated__/graphql';
 
 import TeaseRecordingStack from '../teaseRecordingStack';

--- a/src/components/molecules/card/sequence.tsx
+++ b/src/components/molecules/card/sequence.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/sermon.spec.tsx
+++ b/src/components/molecules/card/sermon.spec.tsx
@@ -47,13 +47,6 @@ describe('card sermon', () => {
 		expect(getByLabelText('play')).toBeInTheDocument();
 	});
 
-	// TODO: fix when usePlaybackSession returns server-side progress
-	// it('disables progress bar interactivity', async () => {
-	// 	const { getByLabelText } = await renderComponent();
-
-	// 	expect(getByLabelText('progress')).toBeDisabled();
-	// });
-
 	it('does not render 0 if 0 duration', async () => {
 		const { queryByText } = await renderComponent({
 			props: {
@@ -61,27 +54,12 @@ describe('card sermon', () => {
 					id: 'the_recording_id',
 					canonicalPath: 'the_sermon_path',
 					persons: [],
+					duration: 0,
 				},
-				duration: 0,
 			},
 		});
 
 		expect(queryByText('0')).not.toBeInTheDocument();
-	});
-
-	it('does not render progress if no progress', async () => {
-		const { queryByLabelText } = await renderComponent({
-			props: {
-				recording: {
-					id: 'the_recording_id',
-					canonicalPath: 'the_sermon_path',
-					persons: [],
-				},
-				progress: 0,
-			},
-		});
-
-		expect(queryByLabelText('progress')).not.toBeInTheDocument();
 	});
 
 	it('has favorite button', async () => {

--- a/src/components/molecules/card/sermon.spec.tsx
+++ b/src/components/molecules/card/sermon.spec.tsx
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/react';
-import React from 'react';
 
 import CardSermon, { CardSermonProps } from '~components/molecules/card/sermon';
 import AndMiniplayer from '~components/templates/andMiniplayer';

--- a/src/components/molecules/card/sermon.tsx
+++ b/src/components/molecules/card/sermon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TeaseRecording from '../teaseRecording';
 import { CardRecordingFragment } from './__generated__/recording';
 import CardWithTheme from './base/withTheme';

--- a/src/components/molecules/card/song.tsx
+++ b/src/components/molecules/card/song.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TeaseRecording from '../teaseRecording';
 import { CardRecordingFragment } from './__generated__/recording';
 import CardWithTheme from './base/withTheme';

--- a/src/components/molecules/card/songBook.tsx
+++ b/src/components/molecules/card/songBook.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import startCase from 'lodash/startCase';
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/sponsor.tsx
+++ b/src/components/molecules/card/sponsor.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/card/story.tsx
+++ b/src/components/molecules/card/story.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import TeaseRecording from '../teaseRecording';
 import { CardRecordingFragment } from './__generated__/recording';
 import CardWithTheme from './base/withTheme';

--- a/src/components/molecules/card/topic.tsx
+++ b/src/components/molecules/card/topic.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import HatIcon from '../../../../public/img/icons/fa-layer-group.svg';
 import TeaseRecording from '../teaseRecording';
 import { CardRecordingFragment } from './__generated__/recording';

--- a/src/components/molecules/cardGroup.tsx
+++ b/src/components/molecules/cardGroup.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import styles from '~components/molecules/cardGroup.module.scss';
 

--- a/src/components/molecules/cardMasonry.tsx
+++ b/src/components/molecules/cardMasonry.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import { MasonryProps } from 'masonic';
 import dynamic from 'next/dynamic';
-import React from 'react';
 
 import styles from './cardMasonry.module.scss';
 

--- a/src/components/molecules/circleButton.tsx
+++ b/src/components/molecules/circleButton.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { MouseEvent, PropsWithChildren, Ref } from 'react';
+import { forwardRef, MouseEvent, PropsWithChildren, Ref } from 'react';
 
 import { BaseColors } from '~lib/constants';
 
@@ -14,7 +14,7 @@ export type ICircleButtonProps = PropsWithChildren<{
 	ref?: Ref<HTMLButtonElement>;
 }>;
 
-const CircleButton: React.FC<ICircleButtonProps> = React.forwardRef(
+const CircleButton: React.FC<ICircleButtonProps> = forwardRef(
 	function CircleButton(
 		{
 			onClick,

--- a/src/components/molecules/collectionTypeLockup.tsx
+++ b/src/components/molecules/collectionTypeLockup.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { BaseColors } from '~lib/constants';

--- a/src/components/molecules/contentWidthLimiter.tsx
+++ b/src/components/molecules/contentWidthLimiter.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import styles from './contentWidthLimiter.module.scss';
 

--- a/src/components/molecules/copyrightInfo.tsx
+++ b/src/components/molecules/copyrightInfo.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { RecordingContentType } from '~src/__generated__/graphql';

--- a/src/components/molecules/definitionList.tsx
+++ b/src/components/molecules/definitionList.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React from 'react';
+import { Fragment } from 'react';
 
 import Heading6 from '~components/atoms/heading6';
 import { BaseColors } from '~lib/constants';
@@ -22,17 +22,17 @@ export default function DefinitionList({
 	textColor,
 }: Props): JSX.Element {
 	return (
-		<dl className={clsx(styles.dl, baseColorStyles[textColor])}>
+        <dl className={clsx(styles.dl, baseColorStyles[textColor])}>
 			{terms.map(({ term, definition }, index) => (
-				<React.Fragment key={index}>
+				<Fragment key={index}>
 					<dt className={styles.dt}>
 						<Heading6 sans unpadded uppercase>
 							{term}
 						</Heading6>
 					</dt>
 					<dd className={styles.dd}>{definition}</dd>
-				</React.Fragment>
+				</Fragment>
 			))}
 		</dl>
-	);
+    );
 }

--- a/src/components/molecules/definitionList.tsx
+++ b/src/components/molecules/definitionList.tsx
@@ -22,7 +22,7 @@ export default function DefinitionList({
 	textColor,
 }: Props): JSX.Element {
 	return (
-        <dl className={clsx(styles.dl, baseColorStyles[textColor])}>
+		<dl className={clsx(styles.dl, baseColorStyles[textColor])}>
 			{terms.map(({ term, definition }, index) => (
 				<Fragment key={index}>
 					<dt className={styles.dt}>
@@ -34,5 +34,5 @@ export default function DefinitionList({
 				</Fragment>
 			))}
 		</dl>
-    );
+	);
 }

--- a/src/components/molecules/downloadAppButton.tsx
+++ b/src/components/molecules/downloadAppButton.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import IconDisclosure from '../../../public/img/icons/icon-disclosure-light-small.svg';

--- a/src/components/molecules/dropdown.tsx
+++ b/src/components/molecules/dropdown.tsx
@@ -1,5 +1,5 @@
 import dynamic from 'next/dynamic';
-import React, { MouseEvent, ReactNode } from 'react';
+import { MouseEvent, ReactNode,useState } from 'react';
 
 import styles from './dropdown.module.scss';
 
@@ -22,7 +22,7 @@ export default function Dropdown({
 	children,
 	alignment = 'right',
 }: Props): JSX.Element {
-	const [anchorEl, setAnchorEl] = React.useState<Element | null>(null);
+	const [anchorEl, setAnchorEl] = useState<Element | null>(null);
 
 	const handleClick = (event: MouseEvent) => {
 		setAnchorEl(event.currentTarget);

--- a/src/components/molecules/dropdown.tsx
+++ b/src/components/molecules/dropdown.tsx
@@ -1,5 +1,5 @@
 import dynamic from 'next/dynamic';
-import { MouseEvent, ReactNode,useState } from 'react';
+import { MouseEvent, ReactNode, useState } from 'react';
 
 import styles from './dropdown.module.scss';
 

--- a/src/components/molecules/form/checkbox.tsx
+++ b/src/components/molecules/form/checkbox.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styles from './checkbox.module.scss';
 
 type CheckboxOptions = {

--- a/src/components/molecules/form/input.tsx
+++ b/src/components/molecules/form/input.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styles from './input.module.scss';
 
 type InputOptions = {

--- a/src/components/molecules/form/select.tsx
+++ b/src/components/molecules/form/select.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styles from './select.module.scss';
 
 type SelectOptions = {

--- a/src/components/molecules/form/textarea.tsx
+++ b/src/components/molecules/form/textarea.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import styles from './textarea.module.scss';
 
 type TextareaOptions = {

--- a/src/components/molecules/helpWidget.tsx
+++ b/src/components/molecules/helpWidget.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import Script from 'next/script';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Button from '~components/molecules/button';

--- a/src/components/molecules/iconButton.tsx
+++ b/src/components/molecules/iconButton.tsx
@@ -1,4 +1,4 @@
-import React, { Ref } from 'react';
+import { forwardRef, Ref } from 'react';
 
 import { BaseColors } from '~lib/constants';
 
@@ -10,17 +10,15 @@ type Props = {
 	color: BaseColors;
 } & ICircleButtonProps;
 
-const IconButton: React.VoidFunctionComponent<Props> = React.forwardRef(
-	function IconButton(
-		{ Icon, color, ...props }: Props,
-		ref: Ref<HTMLButtonElement>
-	) {
-		return (
-			<CircleButton {...props} ref={ref}>
-				<Icon className={baseColorsStyles[color]} />
-			</CircleButton>
-		);
-	}
-);
+const IconButton = forwardRef(function IconButton(
+	{ Icon, color, ...props }: Props,
+	ref: Ref<HTMLButtonElement>
+) {
+	return (
+		<CircleButton {...props} ref={ref}>
+			<Icon className={baseColorsStyles[color]} />
+		</CircleButton>
+	);
+});
 
 export default IconButton;

--- a/src/components/molecules/jumpBar.tsx
+++ b/src/components/molecules/jumpBar.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import React from 'react';
 
 import styles from './jumpBar.module.scss';
 

--- a/src/components/molecules/languageAlternativesAlert.tsx
+++ b/src/components/molecules/languageAlternativesAlert.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { Router, useRouter } from 'next/router';
-import React, { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import InfoBox from '~components/atoms/infoBox';
@@ -19,7 +19,7 @@ const SUPPORTED_ROUTES = [
 ];
 
 export default function LanguageAlternativesAlert(): JSX.Element | null {
-	const [showingAlert, setShowingAlert] = React.useState(false);
+	const [showingAlert, setShowingAlert] = useState(false);
 	const languageRoute = useLanguageRoute();
 
 	const router = useRouter();

--- a/src/components/molecules/languageButton.tsx
+++ b/src/components/molecules/languageButton.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 
 import { LANGUAGES } from '~lib/constants';
 import { getLanguageIdByRoute } from '~lib/getLanguageIdByRoute';

--- a/src/components/molecules/linkButton.tsx
+++ b/src/components/molecules/linkButton.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import styles from './linkButton.module.scss';
 

--- a/src/components/molecules/loadingCards.tsx
+++ b/src/components/molecules/loadingCards.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import { ExtendedCardTheme } from './card/base/withCardTheme';

--- a/src/components/molecules/loadingIndicator.spec.tsx
+++ b/src/components/molecules/loadingIndicator.spec.tsx
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/react';
-import React from 'react';
 
 import LoadingIndicator from '~components/molecules/loadingIndicator';
 import renderWithProviders from '~lib/test/renderWithProviders';

--- a/src/components/molecules/loadingIndicator.tsx
+++ b/src/components/molecules/loadingIndicator.tsx
@@ -1,6 +1,6 @@
 import { useIsFetching } from '@tanstack/react-query';
 import clsx from 'clsx';
-import React, { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import useRouterLoading from '~lib/useRouterLoading';
 
@@ -8,11 +8,11 @@ import styles from './loadingIndicator.module.scss';
 
 const HIDE_DELAY = 1000; //ms
 
-const LoadingIndicator: React.VoidFunctionComponent = () => {
+const LoadingIndicator = () => {
 	const isFetching = useIsFetching();
 	const isLoading = useRouterLoading();
 	const isAnyLoading = !!(isFetching || isLoading);
-	const [visible, setVisible] = React.useState(false);
+	const [visible, setVisible] = useState(false);
 
 	useEffect(() => {
 		if (isAnyLoading) {

--- a/src/components/molecules/login.spec.tsx
+++ b/src/components/molecules/login.spec.tsx
@@ -2,7 +2,6 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { when } from 'jest-when';
 import { __loadRouter } from 'next/router';
-import React from 'react';
 
 import Login from '~components/molecules/login';
 import { fetchApi } from '~lib/api/fetchApi';

--- a/src/components/molecules/login.tsx
+++ b/src/components/molecules/login.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import React from 'react';
 
 import AndOnboarding from '~components/templates/andOnboarding';
 import root from '~lib/routes';

--- a/src/components/molecules/loginForm.tsx
+++ b/src/components/molecules/loginForm.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import clsx from 'clsx';
-import React, { FormEvent, useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Alert from '~components/atoms/alert';

--- a/src/components/molecules/mediaFormatSwitcher.tsx
+++ b/src/components/molecules/mediaFormatSwitcher.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import hasVideo from '~lib/hasVideo';

--- a/src/components/molecules/mininav.tsx
+++ b/src/components/molecules/mininav.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import Link from 'next/link';
-import React, { MouseEvent } from 'react';
+import { MouseEvent } from 'react';
 
 import styles from './mininav.module.scss';
 

--- a/src/components/molecules/namedAvatar.tsx
+++ b/src/components/molecules/namedAvatar.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 
 import RoundImage from '~components/atoms/roundImage';
 import { BaseColors } from '~lib/constants';

--- a/src/components/molecules/navItem.tsx
+++ b/src/components/molecules/navItem.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import ActiveLink from '~components/atoms/activeLink';
 // TODO: Split into its own SCSS module
 import styles from '~components/organisms/navigation.module.scss';

--- a/src/components/molecules/pagination.spec.tsx
+++ b/src/components/molecules/pagination.spec.tsx
@@ -1,6 +1,6 @@
 import { QueryClient } from '@tanstack/react-query';
 import { RenderOptions, RenderResult, screen } from '@testing-library/react';
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 
 import renderWithProviders from '~lib/test/renderWithProviders';
 

--- a/src/components/molecules/pagination.tsx
+++ b/src/components/molecules/pagination.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import Link from 'next/link';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import useLanguageRoute from '~lib/useLanguageRoute';

--- a/src/components/molecules/personLockup.tsx
+++ b/src/components/molecules/personLockup.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { PersonLockupFragment } from './__generated__/personLockup';
 import NamedAvatar, { INamedAvatarProps } from './namedAvatar';
 

--- a/src/components/molecules/personTypeLockup.tsx
+++ b/src/components/molecules/personTypeLockup.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { BaseColors } from '~lib/constants';

--- a/src/components/molecules/playbackTimes.tsx
+++ b/src/components/molecules/playbackTimes.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useFormattedTime } from '~lib/time';
 import usePlaybackSession from '~lib/usePlaybackSession';
 

--- a/src/components/molecules/player.spec.tsx
+++ b/src/components/molecules/player.spec.tsx
@@ -10,7 +10,6 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { __loadRouter } from 'next/router';
-import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import videojs from 'video.js';
 

--- a/src/components/molecules/player.tsx
+++ b/src/components/molecules/player.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import Image from 'next/legacy/image';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import ButtonDownload from '~components/molecules/buttonDownload';

--- a/src/components/molecules/recordingButtonFavorite.spec.tsx
+++ b/src/components/molecules/recordingButtonFavorite.spec.tsx
@@ -2,7 +2,6 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Cookie from 'js-cookie';
 import { __loadRouter } from 'next/router';
-import React from 'react';
 
 import RecordingButtonFavorite from '~components/molecules/recordingButtonFavorite';
 import { recordingIsFavorited } from '~lib/api/recordingIsFavorited';

--- a/src/components/molecules/recordingButtonFavorite.tsx
+++ b/src/components/molecules/recordingButtonFavorite.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useIsRecordingFavorited } from '~lib/api/useIsRecordingFavorited';
 import { BaseColors } from '~lib/constants';
 import { Scalars } from '~src/__generated__/graphql';

--- a/src/components/molecules/recordingHasVideoFilter.tsx
+++ b/src/components/molecules/recordingHasVideoFilter.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Button from '~components/molecules/button';

--- a/src/components/molecules/recordingProgressBar.tsx
+++ b/src/components/molecules/recordingProgressBar.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { AndMiniplayerFragment } from '~components/templates/__generated__/andMiniplayer';
 import usePlaybackSession from '~lib/usePlaybackSession';
 

--- a/src/components/molecules/rssAlternate.tsx
+++ b/src/components/molecules/rssAlternate.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 export default function RssAlternate({ url }: { url: string }): JSX.Element {

--- a/src/components/molecules/searchBar.tsx
+++ b/src/components/molecules/searchBar.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import {
@@ -38,7 +38,7 @@ export default function SearchBar({
 	const intl = useIntl();
 	const [isFocused, setIsFocused] = useState(false);
 	const [lastTerm, setLastTerm] = useState(term);
-	const inputRef = React.useRef<HTMLInputElement>(null);
+	const inputRef = useRef<HTMLInputElement>(null);
 
 	const handleSubmit = useCallback(
 		(e: KeyboardEvent) => e.key === 'Enter' && onSubmit?.(),

--- a/src/components/molecules/sequenceNav.tsx
+++ b/src/components/molecules/sequenceNav.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import IconBack from '../../../public/img/icons/icon-back-light.svg';

--- a/src/components/molecules/sequenceTypeLockup.tsx
+++ b/src/components/molecules/sequenceTypeLockup.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { getSequenceTypeTheme } from '~lib/getSequenceType';
 import { SequenceContentType } from '~src/__generated__/graphql';
 

--- a/src/components/molecules/socialLogin.spec.tsx
+++ b/src/components/molecules/socialLogin.spec.tsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { when } from 'jest-when';
-import React from 'react';
 
 import SocialLogin from '~components/molecules/socialLogin';
 import { RegisterSocialDocument } from '~containers/account/__generated__/register';

--- a/src/components/molecules/socialLogin.tsx
+++ b/src/components/molecules/socialLogin.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
 	ReactFacebookFailureResponse,
 	ReactFacebookLoginInfo,

--- a/src/components/molecules/sponsorLockup.tsx
+++ b/src/components/molecules/sponsorLockup.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { SponsorLockupFragment } from './__generated__/sponsorLockup';
 import NamedAvatar, { INamedAvatarProps } from './namedAvatar';
 

--- a/src/components/molecules/sponsorTypeLockup.tsx
+++ b/src/components/molecules/sponsorTypeLockup.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { BaseColors } from '~lib/constants';

--- a/src/components/molecules/tease.tsx
+++ b/src/components/molecules/tease.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import styles from '~components/molecules/tease.module.scss';
 

--- a/src/components/molecules/teaseRecording.tsx
+++ b/src/components/molecules/teaseRecording.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/molecules/teaseRecordingStack.tsx
+++ b/src/components/molecules/teaseRecordingStack.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React from 'react';
+import { Fragment } from 'react';
 
 import TeaseRecording from '~components/molecules/teaseRecording';
 
@@ -23,9 +23,9 @@ export default function TeaseRecordingStack({
 }: Props): JSX.Element | null {
 	// TODO: add expand/contract?
 	return (
-		<WithCardTheme theme={theme} className={styles.base}>
+        <WithCardTheme theme={theme} className={styles.base}>
 			{recordings.map((recording, index) => (
-				<React.Fragment key={recording.canonicalPath}>
+				<Fragment key={recording.canonicalPath}>
 					<TeaseRecording
 						{...{ recording, theme, ...props }}
 						small={recordings.length > 1 || allSmall}
@@ -33,8 +33,8 @@ export default function TeaseRecordingStack({
 					{index + 1 < recordings.length && (
 						<div className={clsx(styles.separator, styles.paddedSeparator)} />
 					)}
-				</React.Fragment>
+				</Fragment>
 			))}
 		</WithCardTheme>
-	);
+    );
 }

--- a/src/components/molecules/teaseRecordingStack.tsx
+++ b/src/components/molecules/teaseRecordingStack.tsx
@@ -23,7 +23,7 @@ export default function TeaseRecordingStack({
 }: Props): JSX.Element | null {
 	// TODO: add expand/contract?
 	return (
-        <WithCardTheme theme={theme} className={styles.base}>
+		<WithCardTheme theme={theme} className={styles.base}>
 			{recordings.map((recording, index) => (
 				<Fragment key={recording.canonicalPath}>
 					<TeaseRecording
@@ -36,5 +36,5 @@ export default function TeaseRecordingStack({
 				</Fragment>
 			))}
 		</WithCardTheme>
-    );
+	);
 }

--- a/src/components/molecules/transcript.tsx
+++ b/src/components/molecules/transcript.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Alert from '~components/atoms/alert';

--- a/src/components/molecules/typeLockup.tsx
+++ b/src/components/molecules/typeLockup.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 
 import Heading6 from '~components/atoms/heading6';
 import { BaseColors } from '~lib/constants';

--- a/src/components/organisms/__generated__/notFound.ts
+++ b/src/components/organisms/__generated__/notFound.ts
@@ -55,7 +55,8 @@ export const useInfiniteGetNotFoundPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getNotFoundPageData<T>(
 	variables: ExactAlt<T, GetNotFoundPageDataQueryVariables>

--- a/src/components/organisms/__generated__/searchResults.ts
+++ b/src/components/organisms/__generated__/searchResults.ts
@@ -449,7 +449,8 @@ export const useInfiniteGetSearchStoryProgramsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchRecordings<T>(
 	variables: ExactAlt<T, GetSearchRecordingsQueryVariables>

--- a/src/components/organisms/aboutNav.tsx
+++ b/src/components/organisms/aboutNav.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Mininav from '~components/molecules/mininav';
 import { useNavigationItems } from '~lib/useNavigationItems';
 

--- a/src/components/organisms/accountNav.tsx
+++ b/src/components/organisms/accountNav.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Mininav from '~components/molecules/mininav';

--- a/src/components/organisms/drawer.tsx
+++ b/src/components/organisms/drawer.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { Router } from 'next/router';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import Header from '~components/organisms/header';
 import Navigation from '~components/organisms/navigation';

--- a/src/components/organisms/emptyState.tsx
+++ b/src/components/organisms/emptyState.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Alert from '~components/atoms/alert';

--- a/src/components/organisms/footer.tsx
+++ b/src/components/organisms/footer.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/legacy/image';
 import { useRouter } from 'next/router';
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading3 from '~components/atoms/heading3';

--- a/src/components/organisms/header.spec.tsx
+++ b/src/components/organisms/header.spec.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Header from '~components/organisms/header';
 import renderWithProviders from '~lib/test/renderWithProviders';
 

--- a/src/components/organisms/header.tsx
+++ b/src/components/organisms/header.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/legacy/image';
 import Link from 'next/link';
-import React from 'react';
 
 import useLanguageRoute from '~lib/useLanguageRoute';
 

--- a/src/components/organisms/libraryNav.tsx
+++ b/src/components/organisms/libraryNav.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading6 from '~components/atoms/heading6';

--- a/src/components/organisms/miniplayer.tsx
+++ b/src/components/organisms/miniplayer.tsx
@@ -3,7 +3,7 @@ import 'video.js/dist/video-js.css';
 import Slider from '@material-ui/core/Slider';
 import clsx from 'clsx';
 import Link from 'next/link';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { useIntl } from 'react-intl';
 
 import ButtonNudge from '~components/molecules/buttonNudge';

--- a/src/components/organisms/mobileHeader.tsx
+++ b/src/components/organisms/mobileHeader.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Button from '~components/molecules/button';

--- a/src/components/organisms/mobileHeader.useTransitionProgress.ts
+++ b/src/components/organisms/mobileHeader.useTransitionProgress.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import isServerSide from '~lib/isServerSide';
 

--- a/src/components/organisms/modal.tsx
+++ b/src/components/organisms/modal.tsx
@@ -1,7 +1,7 @@
 import Backdrop from '@material-ui/core/Backdrop';
 import Fade from '@material-ui/core/Fade';
 import MuiModal from '@material-ui/core/Modal';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { useIntl } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/organisms/modalLoginForm.tsx
+++ b/src/components/organisms/modalLoginForm.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import LoginForm from '~components/molecules/loginForm';
 import SocialLogin from '~components/molecules/socialLogin';
 

--- a/src/components/organisms/modalRegisterForm.tsx
+++ b/src/components/organisms/modalRegisterForm.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import SocialLogin from '~components/molecules/socialLogin';
 
 import RegisterForm from './registerForm';

--- a/src/components/organisms/navigation.spec.tsx
+++ b/src/components/organisms/navigation.spec.tsx
@@ -1,6 +1,5 @@
 import { screen } from '@testing-library/react';
 import { __loadRouter } from 'next/router';
-import React from 'react';
 
 import Navigation from '~components/organisms/navigation';
 import renderWithProviders from '~lib/test/renderWithProviders';

--- a/src/components/organisms/navigation.tsx
+++ b/src/components/organisms/navigation.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import Link from 'next/link';
 import { Router, useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading3 from '~components/atoms/heading3';

--- a/src/components/organisms/notFound.tsx
+++ b/src/components/organisms/notFound.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Alert from '~components/atoms/alert';

--- a/src/components/organisms/paginatedCardList.tsx
+++ b/src/components/organisms/paginatedCardList.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import Heading1 from '~components/atoms/heading1';
 import ButtonBack from '~components/molecules/buttonBack';

--- a/src/components/organisms/recording.tsx
+++ b/src/components/organisms/recording.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import startCase from 'lodash/startCase';
 import Head from 'next/head';
 import Link from 'next/link';
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/components/organisms/registerForm.tsx
+++ b/src/components/organisms/registerForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Button from '~components/molecules/button';

--- a/src/components/organisms/searchResults.filters.tsx
+++ b/src/components/organisms/searchResults.filters.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import {

--- a/src/components/organisms/searchResults.tsx
+++ b/src/components/organisms/searchResults.tsx
@@ -72,27 +72,28 @@ function Section({
 	return (
 		<div className={styles.section}>
 			<LineHeading variant="overline">{section.heading}</LineHeading>
-			<CardGroup>
-				{nodes.map((e: InferrableEntity) => (
-					<CardInferred key={e.id} entity={e} />
-				))}
-				{nodes.length === 0 && (
-					<EmptyState
-						title={
-							<FormattedMessage
-								id="search__emptyStateTitle"
-								defaultMessage="No results found"
-							/>
-						}
-						message={
-							<FormattedMessage
-								id="search__emptyStateMessage"
-								defaultMessage="Try searching for something else"
-							/>
-						}
-					/>
-				)}
-			</CardGroup>
+			{nodes.length ? (
+				<CardGroup>
+					{nodes.map((e: InferrableEntity) => (
+						<CardInferred key={e.id} entity={e} />
+					))}
+				</CardGroup>
+			) : (
+				<EmptyState
+					title={
+						<FormattedMessage
+							id="search__emptyStateTitle"
+							defaultMessage="No results found"
+						/>
+					}
+					message={
+						<FormattedMessage
+							id="search__emptyStateMessage"
+							defaultMessage="Try searching for something else"
+						/>
+					}
+				/>
+			)}
 			{section.hasNextPage && entityType === 'all' && (
 				<Button
 					type="secondary"

--- a/src/components/organisms/searchResults.tsx
+++ b/src/components/organisms/searchResults.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 import React, { RefObject, useEffect, useMemo, useRef, useState } from 'react';
-import { useIntl } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';
 import Button from '~components/molecules/button';
@@ -14,6 +14,7 @@ import isServerSide from '~lib/isServerSide';
 import { useQueryString } from '~lib/useQueryString';
 
 import ForwardIcon from '../../../public/img/icons/icon-forward-light.svg';
+import EmptyState from './emptyState';
 import { EntityFilterId } from './searchResults.filters';
 import styles from './searchResults.module.scss';
 import useSearch, { AugmentedFilter } from './searchResults.useResults';
@@ -75,6 +76,22 @@ function Section({
 				{nodes.map((e: InferrableEntity) => (
 					<CardInferred key={e.id} entity={e} />
 				))}
+				{nodes.length === 0 && (
+					<EmptyState
+						title={
+							<FormattedMessage
+								id="search__emptyStateTitle"
+								defaultMessage="No results found"
+							/>
+						}
+						message={
+							<FormattedMessage
+								id="search__emptyStateMessage"
+								defaultMessage="Try searching for something else"
+							/>
+						}
+					/>
+				)}
 			</CardGroup>
 			{section.hasNextPage && entityType === 'all' && (
 				<Button

--- a/src/components/organisms/searchResults.tsx
+++ b/src/components/organisms/searchResults.tsx
@@ -122,7 +122,7 @@ function hasExactMatch(term: string, sections: AugmentedFilter[]): boolean {
 
 export default function Search({
 	term,
-	entityType,
+	entityType = 'all',
 	onEntityTypeChange,
 }: {
 	term?: string;

--- a/src/components/organisms/searchResults.tsx
+++ b/src/components/organisms/searchResults.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import React, { RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { RefObject, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/components/organisms/section.tsx
+++ b/src/components/organisms/section.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import React from 'react';
 
 import { BaseColors } from '~lib/constants';
 

--- a/src/components/organisms/sequence.tsx
+++ b/src/components/organisms/sequence.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/components/organisms/slider.spec.tsx
+++ b/src/components/organisms/slider.spec.tsx
@@ -1,5 +1,4 @@
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 
 import CardSermon from '~components/molecules/card/sermon';
 import Slider from '~components/organisms/slider';

--- a/src/components/organisms/slider.tsx
+++ b/src/components/organisms/slider.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { ReactNode, useState } from 'react';
+import { Children, ReactNode, useState } from 'react';
 import { useIntl } from 'react-intl';
 
 import Button from '~components/molecules/button';
@@ -30,11 +30,11 @@ export default function Slider({
 	const intl = useIntl();
 	const [delta, setDelta] = useState<number>(0);
 
-	if (floatingControls && React.Children.count(children) > 5) {
+	if (floatingControls && Children.count(children) > 5) {
 		throw new Error('Unsupported number of children');
 	}
 
-	const array = React.Children.toArray(children);
+	const array = Children.toArray(children);
 	const pageCount = Math.ceil(array.length / perSlide);
 	const pageIndices = Array.from(new Array(pageCount).keys());
 

--- a/src/components/organisms/testimonies.tsx
+++ b/src/components/organisms/testimonies.tsx
@@ -9,7 +9,7 @@ interface TestimoniesProps {
 
 const Testimonies = ({ testimonies }: TestimoniesProps): JSX.Element => {
 	return (
-        <Slider>
+		<Slider>
 			{testimonies.map((t) => (
 				<blockquote className={styles.testimony} key={t.id}>
 					<p
@@ -22,7 +22,7 @@ const Testimonies = ({ testimonies }: TestimoniesProps): JSX.Element => {
 				</blockquote>
 			))}
 		</Slider>
-    );
+	);
 };
 
 export default Testimonies;

--- a/src/components/organisms/testimonies.tsx
+++ b/src/components/organisms/testimonies.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Slider from '~components/organisms/slider';
 
 import { TestimoniesFragment } from './__generated__/testimonies';
@@ -11,7 +9,7 @@ interface TestimoniesProps {
 
 const Testimonies = ({ testimonies }: TestimoniesProps): JSX.Element => {
 	return (
-		<Slider>
+        <Slider>
 			{testimonies.map((t) => (
 				<blockquote className={styles.testimony} key={t.id}>
 					<p
@@ -24,7 +22,7 @@ const Testimonies = ({ testimonies }: TestimoniesProps): JSX.Element => {
 				</blockquote>
 			))}
 		</Slider>
-	);
+    );
 };
 
 export default Testimonies;

--- a/src/components/templates/__generated__/andMiniplayer.ts
+++ b/src/components/templates/__generated__/andMiniplayer.ts
@@ -112,7 +112,8 @@ export const useRecordingPlaybackProgressSetMutation = <
       (variables?: RecordingPlaybackProgressSetMutationVariables) => graphqlFetcher<RecordingPlaybackProgressSetMutation, RecordingPlaybackProgressSetMutationVariables>(RecordingPlaybackProgressSetDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getRecordingPlaybackProgress<T>(
 	variables: ExactAlt<T, GetRecordingPlaybackProgressQueryVariables>

--- a/src/components/templates/andGlobalModals.tsx
+++ b/src/components/templates/andGlobalModals.tsx
@@ -14,12 +14,10 @@ export type GlobalModalsContextType = {
 	confirmRemoveFavorite: (onConfirm: () => unknown) => void;
 };
 
-export const GlobalModalsContext = createContext<GlobalModalsContextType>(
-	{
-		challengeAuth: () => undefined,
-		confirmRemoveFavorite: () => void 0,
-	}
-);
+export const GlobalModalsContext = createContext<GlobalModalsContextType>({
+	challengeAuth: () => undefined,
+	confirmRemoveFavorite: () => void 0,
+});
 
 const LazyModal = dynamic(() => import('../organisms/modal'));
 const LazyModalRegisterForm = dynamic(

--- a/src/components/templates/andGlobalModals.tsx
+++ b/src/components/templates/andGlobalModals.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
-import React, { ReactNode, useState } from 'react';
+import { createContext, ReactNode, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Button from '~components/molecules/button';
@@ -14,7 +14,7 @@ export type GlobalModalsContextType = {
 	confirmRemoveFavorite: (onConfirm: () => unknown) => void;
 };
 
-export const GlobalModalsContext = React.createContext<GlobalModalsContextType>(
+export const GlobalModalsContext = createContext<GlobalModalsContextType>(
 	{
 		challengeAuth: () => undefined,
 		confirmRemoveFavorite: () => void 0,

--- a/src/components/templates/andMiniplayer.spec.tsx
+++ b/src/components/templates/andMiniplayer.spec.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 
 import AndMiniplayer from '~components/templates/andMiniplayer';
 import AndPlaybackContext, {

--- a/src/components/templates/andMiniplayer.tsx
+++ b/src/components/templates/andMiniplayer.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import dynamic from 'next/dynamic';
-import React, { PropsWithChildren, useContext, useEffect } from 'react';
+import { PropsWithChildren, useContext, useEffect } from 'react';
 
 import styles from './andMiniplayer.module.scss';
 import { PlaybackContext } from './andPlaybackContext';

--- a/src/components/templates/andNavigation.spec.tsx
+++ b/src/components/templates/andNavigation.spec.tsx
@@ -93,9 +93,7 @@ describe('AndNavigation', () => {
 			name: 'Presenters',
 		});
 
-		expect(teachingsHeading.compareDocumentPosition(presentersHeading)).toBe(
-			Node.DOCUMENT_POSITION_FOLLOWING
-		);
+		expect(teachingsHeading).toAppearBefore(presentersHeading);
 	});
 
 	it('ignores case when hoisting teachings', async () => {
@@ -113,9 +111,7 @@ describe('AndNavigation', () => {
 			name: 'Presenters',
 		});
 
-		expect(teachingsHeading.compareDocumentPosition(presentersHeading)).toBe(
-			Node.DOCUMENT_POSITION_FOLLOWING
-		);
+		expect(teachingsHeading).toAppearBefore(presentersHeading);
 	});
 
 	it('ignores punctuation when hoisting teachings', async () => {
@@ -133,9 +129,7 @@ describe('AndNavigation', () => {
 			name: 'Presenters',
 		});
 
-		expect(teachingsHeading.compareDocumentPosition(presentersHeading)).toBe(
-			Node.DOCUMENT_POSITION_FOLLOWING
-		);
+		expect(teachingsHeading).toAppearBefore(presentersHeading);
 	});
 
 	it('debounces search queries', async () => {

--- a/src/components/templates/andNavigation.spec.tsx
+++ b/src/components/templates/andNavigation.spec.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { CardPersonFragment } from '~components/molecules/card/__generated__/person';
 import { CardRecordingFragment } from '~components/molecules/card/__generated__/recording';
 import {
+	GetSearchAudiobooksDocument,
 	GetSearchPersonsDocument,
 	GetSearchRecordingsDocument,
 } from '~components/organisms/__generated__/searchResults';
@@ -153,6 +154,56 @@ describe('AndNavigation', () => {
 				expect.objectContaining({
 					variables: expect.objectContaining({
 						term: 'abc',
+					}),
+				})
+			);
+		});
+
+		expect(fetchApi).not.toBeCalledWith(
+			GetSearchRecordingsDocument,
+			expect.objectContaining({
+				variables: expect.objectContaining({
+					term: 'ab',
+				}),
+			})
+		);
+	});
+
+	it('disables queries for inactive tabs', async () => {
+		const user = userEvent.setup();
+
+		await renderTemplate();
+
+		const searchInputs = screen.getAllByPlaceholderText('Search');
+		const search = searchInputs[0];
+
+		await user.type(search, 'a');
+
+		await waitFor(() => {
+			expect(fetchApi).toBeCalledWith(
+				GetSearchRecordingsDocument,
+				expect.objectContaining({
+					variables: expect.objectContaining({
+						term: 'a',
+					}),
+				})
+			);
+		});
+
+		const tabs = await screen.findAllByRole('button', {
+			name: 'Audiobooks',
+		});
+
+		user.click(tabs[0]);
+
+		await user.type(search, 'b');
+
+		await waitFor(() => {
+			expect(fetchApi).toBeCalledWith(
+				GetSearchAudiobooksDocument,
+				expect.objectContaining({
+					variables: expect.objectContaining({
+						term: 'ab',
 					}),
 				})
 			);

--- a/src/components/templates/andNavigation.tsx
+++ b/src/components/templates/andNavigation.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
-import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 
 import LanguageAlternativesAlert from '~components/molecules/languageAlternativesAlert';
 import SearchBar from '~components/molecules/searchBar';

--- a/src/components/templates/andOnboarding.tsx
+++ b/src/components/templates/andOnboarding.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/components/templates/andPlaybackContext.tsx
+++ b/src/components/templates/andPlaybackContext.tsx
@@ -2,14 +2,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import throttle from 'lodash/throttle';
 import Script from 'next/script';
 import {
-    createContext,
-    MutableRefObject,
-    ReactNode,
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
+	createContext,
+	MutableRefObject,
+	ReactNode,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
 } from 'react';
 import type * as VideoJs from 'video.js';
 

--- a/src/components/templates/andPlaybackContext.tsx
+++ b/src/components/templates/andPlaybackContext.tsx
@@ -1,14 +1,15 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import throttle from 'lodash/throttle';
 import Script from 'next/script';
-import React, {
-	MutableRefObject,
-	ReactNode,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
+import {
+    createContext,
+    MutableRefObject,
+    ReactNode,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
 } from 'react';
 import type * as VideoJs from 'video.js';
 
@@ -125,7 +126,7 @@ export type PlaybackContextType = {
 	) => void;
 };
 
-export const PlaybackContext = React.createContext<PlaybackContextType>({
+export const PlaybackContext = createContext<PlaybackContextType>({
 	player: () => undefined,
 	play: () => undefined,
 	pause: () => undefined,

--- a/src/containers/__generated__/blog.ts
+++ b/src/containers/__generated__/blog.ts
@@ -100,7 +100,8 @@ export const useInfiniteGetBlogPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getBlogPageData<T>(
 	variables: ExactAlt<T, GetBlogPageDataQueryVariables>

--- a/src/containers/__generated__/contact.ts
+++ b/src/containers/__generated__/contact.ts
@@ -33,7 +33,8 @@ export const useSubmitContactPageMutation = <
       (variables?: SubmitContactPageMutationVariables) => graphqlFetcher<SubmitContactPageMutation, SubmitContactPageMutationVariables>(SubmitContactPageDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function submitContactPage<T>(
 	variables: ExactAlt<T, SubmitContactPageMutationVariables>

--- a/src/containers/__generated__/home.ts
+++ b/src/containers/__generated__/home.ts
@@ -86,7 +86,8 @@ export const useInfiniteGetHomeStaticPropsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getHomeStaticProps<T>(
 	variables: ExactAlt<T, GetHomeStaticPropsQueryVariables>

--- a/src/containers/__generated__/testimonies.ts
+++ b/src/containers/__generated__/testimonies.ts
@@ -101,7 +101,8 @@ export const useInfiniteGetTestimoniesPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getTestimoniesPageData<T>(
 	variables: ExactAlt<T, GetTestimoniesPageDataQueryVariables>

--- a/src/containers/about/__generated__/index.ts
+++ b/src/containers/about/__generated__/index.ts
@@ -92,7 +92,8 @@ export const useInfiniteGetAboutStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAboutPageData<T>(
 	variables: ExactAlt<T, GetAboutPageDataQueryVariables>

--- a/src/containers/about/index.tsx
+++ b/src/containers/about/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Heading1 from '~components/atoms/heading1';
 import withFailStates from '~components/HOCs/withFailStates';
 import ContentWidthLimiter from '~components/molecules/contentWidthLimiter';

--- a/src/containers/about/index.tsx
+++ b/src/containers/about/index.tsx
@@ -4,6 +4,7 @@ import Heading1 from '~components/atoms/heading1';
 import withFailStates from '~components/HOCs/withFailStates';
 import ContentWidthLimiter from '~components/molecules/contentWidthLimiter';
 import AboutNav from '~components/organisms/aboutNav';
+import { Must } from '~src/types/types';
 
 import { GetAboutPageDataQuery } from './__generated__';
 import styles from './index.module.scss';

--- a/src/containers/about/purpose.tsx
+++ b/src/containers/about/purpose.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import Image from 'next/legacy/image';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/about/spirit.tsx
+++ b/src/containers/about/spirit.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/about/story.tsx
+++ b/src/containers/about/story.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/legacy/image';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/about/team.tsx
+++ b/src/containers/about/team.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/legacy/image';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/account/__generated__/preferences.ts
+++ b/src/containers/account/__generated__/preferences.ts
@@ -88,7 +88,8 @@ export const useUpdateAccountPreferencesMutation = <
       (variables?: UpdateAccountPreferencesMutationVariables) => graphqlFetcher<UpdateAccountPreferencesMutation, UpdateAccountPreferencesMutationVariables>(UpdateAccountPreferencesDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAccountPreferencesData<T>(
 	variables: ExactAlt<T, GetAccountPreferencesDataQueryVariables>

--- a/src/containers/account/__generated__/profile.ts
+++ b/src/containers/account/__generated__/profile.ts
@@ -120,7 +120,8 @@ export const useDeleteAccountMutation = <
       (variables?: DeleteAccountMutationVariables) => graphqlFetcher<DeleteAccountMutation, DeleteAccountMutationVariables>(DeleteAccountDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getProfileData<T>(
 	variables: ExactAlt<T, GetProfileDataQueryVariables>

--- a/src/containers/account/__generated__/register.ts
+++ b/src/containers/account/__generated__/register.ts
@@ -70,7 +70,8 @@ export const useRegisterSocialMutation = <
       (variables?: RegisterSocialMutationVariables) => graphqlFetcher<RegisterSocialMutation, RegisterSocialMutationVariables>(RegisterSocialDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function register<T>(
 	variables: ExactAlt<T, RegisterMutationVariables>

--- a/src/containers/account/__generated__/reset.ts
+++ b/src/containers/account/__generated__/reset.ts
@@ -30,7 +30,8 @@ export const useResetPasswordMutation = <
       (variables?: ResetPasswordMutationVariables) => graphqlFetcher<ResetPasswordMutation, ResetPasswordMutationVariables>(ResetPasswordDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function resetPassword<T>(
 	variables: ExactAlt<T, ResetPasswordMutationVariables>

--- a/src/containers/account/loginRedirect.tsx
+++ b/src/containers/account/loginRedirect.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import root, { isRedirectRouteAllowed } from '~lib/routes';

--- a/src/containers/account/logout.spec.tsx
+++ b/src/containers/account/logout.spec.tsx
@@ -14,7 +14,7 @@ describe('logout route', () => {
 		mockUseLogout.mockResolvedValue(undefined);
 
 		await act(async () => {
-			await renderPage({ router: { push: () => Promise.resolve(true) } });
+			await renderPage();
 		});
 
 		expect(useLogout).toBeCalled();

--- a/src/containers/account/preferences.tsx
+++ b/src/containers/account/preferences.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import capitalize from 'lodash/capitalize';
-import React, { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/account/profile.spec.tsx
+++ b/src/containers/account/profile.spec.tsx
@@ -6,7 +6,6 @@ import Cookie from 'js-cookie';
 import get from 'lodash/get';
 import { GetServerSidePropsContext } from 'next';
 import { __loadRouter } from 'next/router';
-import React from 'react';
 import ReactTestUtils, { act } from 'react-dom/test-utils';
 
 import { fetchApi } from '~lib/api/fetchApi';

--- a/src/containers/account/profile.tsx
+++ b/src/containers/account/profile.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
-import React, { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/account/register.spec.tsx
+++ b/src/containers/account/register.spec.tsx
@@ -18,35 +18,31 @@ jest.mock('react-google-login');
 
 const renderPage = buildRenderer(Register);
 
-const router = { push: () => jest.fn().mockResolvedValue(true) } as any;
-
 describe('register page', () => {
 	beforeEach(() => {
 		Cookie.get = jest.fn().mockReturnValue({});
 	});
 
 	it('renders email field', async () => {
-		const { getByPlaceholderText } = await renderPage({ router });
+		const { getByPlaceholderText } = await renderPage();
 
 		expect(getByPlaceholderText('jane@example.com')).toBeInTheDocument();
 	});
 
 	it('renders password field', async () => {
-		const { getByPlaceholderText } = await renderPage({ router });
+		const { getByPlaceholderText } = await renderPage();
 
 		expect(getByPlaceholderText('∗∗∗∗∗∗∗')).toBeInTheDocument();
 	});
 
 	it('renders sign up button', async () => {
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		expect(getByText('Sign up')).toBeInTheDocument();
 	});
 
 	it('resets errors on click', async () => {
-		const { getByText, getByPlaceholderText, queryByText } = await renderPage({
-			router,
-		});
+		const { getByText, getByPlaceholderText, queryByText } = await renderPage();
 
 		await userEvent.click(getByText('Sign up'));
 
@@ -58,7 +54,7 @@ describe('register page', () => {
 	});
 
 	it('renders missing email error', async () => {
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(getByText('Sign up'));
 
@@ -66,7 +62,7 @@ describe('register page', () => {
 	});
 
 	it('registers user', async () => {
-		const { getByText, getByPlaceholderText } = await renderPage({ router });
+		const { getByText, getByPlaceholderText } = await renderPage();
 
 		await userEvent.type(getByPlaceholderText('Jane'), 'Matthew');
 		await userEvent.type(getByPlaceholderText('Doe'), 'Leffler');
@@ -88,7 +84,7 @@ describe('register page', () => {
 	});
 
 	it('displays loading state', async () => {
-		const { getByText, getByPlaceholderText } = await renderPage({ router });
+		const { getByText, getByPlaceholderText } = await renderPage();
 
 		await userEvent.type(getByPlaceholderText('jane@example.com'), 'email');
 		await userEvent.type(getByPlaceholderText('∗∗∗∗∗∗∗'), 'pass');
@@ -113,7 +109,7 @@ describe('register page', () => {
 				},
 			});
 
-		const { getByText, getByPlaceholderText } = await renderPage({ router });
+		const { getByText, getByPlaceholderText } = await renderPage();
 
 		await userEvent.type(getByPlaceholderText('jane@example.com'), 'email');
 		await userEvent.type(getByPlaceholderText('∗∗∗∗∗∗∗'), 'pass');
@@ -123,7 +119,7 @@ describe('register page', () => {
 	});
 
 	it('displays success message', async () => {
-		const { getByText, getByPlaceholderText } = await renderPage({ router });
+		const { getByText, getByPlaceholderText } = await renderPage();
 
 		await userEvent.type(getByPlaceholderText('jane@example.com'), 'email');
 		await userEvent.type(getByPlaceholderText('∗∗∗∗∗∗∗'), 'pass');
@@ -136,7 +132,7 @@ describe('register page', () => {
 	});
 
 	it('renders continue with Facebook', async () => {
-		await renderPage({ router });
+		await renderPage();
 
 		expect(
 			await screen.findByText('Sign up with Facebook')
@@ -144,7 +140,7 @@ describe('register page', () => {
 	});
 
 	it('renders continue with Google', async () => {
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		expect(getByText('Sign up with Google')).toBeInTheDocument();
 	});
@@ -162,7 +158,7 @@ describe('register page', () => {
 				},
 			});
 
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(getByText('Sign up with Google'));
 
@@ -184,7 +180,7 @@ describe('register page', () => {
 				},
 			});
 
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -194,7 +190,7 @@ describe('register page', () => {
 	});
 
 	it('renders social login success', async () => {
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -204,7 +200,7 @@ describe('register page', () => {
 	});
 
 	it('hits api with facebook registration', async () => {
-		await renderPage({ router });
+		await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -232,7 +228,7 @@ describe('register page', () => {
 				},
 			});
 
-		await renderPage({ router });
+		await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -248,7 +244,7 @@ describe('register page', () => {
 			status: 300,
 		});
 
-		await renderPage({ router });
+		await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -266,7 +262,7 @@ describe('register page', () => {
 			statusText: 'FAILED',
 		});
 
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(await screen.findByText('Sign up with Facebook'));
 
@@ -280,13 +276,13 @@ describe('register page', () => {
 	it('does not display form if user logged in', async () => {
 		Cookie.get = jest.fn().mockReturnValue({ avSession: 'abc123' });
 
-		const { queryByPlaceholderText } = await renderPage({ router });
+		const { queryByPlaceholderText } = await renderPage();
 
 		expect(queryByPlaceholderText('email')).not.toBeInTheDocument();
 	});
 
 	it('sends Google login data to API', async () => {
-		const { getByText } = await renderPage({ router });
+		const { getByText } = await renderPage();
 
 		await userEvent.click(getByText('Sign up with Google'));
 

--- a/src/containers/account/register.tsx
+++ b/src/containers/account/register.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import React from 'react';
 
 import withAuthGuard from '~components/HOCs/withAuthGuard';
 import SocialLogin from '~components/molecules/socialLogin';

--- a/src/containers/account/reset.tsx
+++ b/src/containers/account/reset.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import React, { FormEvent, useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Alert from '~components/atoms/alert';

--- a/src/containers/audiobook/__generated__/detail.ts
+++ b/src/containers/audiobook/__generated__/detail.ts
@@ -163,7 +163,8 @@ export const useInfiniteGetAudiobookDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobookDetailPageData<T>(
 	variables: ExactAlt<T, GetAudiobookDetailPageDataQueryVariables>

--- a/src/containers/audiobook/__generated__/list.ts
+++ b/src/containers/audiobook/__generated__/list.ts
@@ -102,7 +102,8 @@ export const useInfiniteGetAudiobookListPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobookListPageData<T>(
 	variables: ExactAlt<T, GetAudiobookListPageDataQueryVariables>

--- a/src/containers/audiobook/list.spec.tsx
+++ b/src/containers/audiobook/list.spec.tsx
@@ -1,6 +1,5 @@
 import { when } from 'jest-when';
 import { __loadRouter } from 'next/router';
-import React from 'react';
 
 import { fetchApi } from '~lib/api/fetchApi';
 import { ENTRIES_PER_PAGE } from '~lib/constants';

--- a/src/containers/audiobook/list.tsx
+++ b/src/containers/audiobook/list.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import withFailStates from '~components/HOCs/withFailStates';

--- a/src/containers/audiobook/tracks/__generated__/detail.ts
+++ b/src/containers/audiobook/tracks/__generated__/detail.ts
@@ -106,7 +106,8 @@ export const useInfiniteGetAudiobookTrackDetailStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobookTrackDetailData<T>(
 	variables: ExactAlt<T, GetAudiobookTrackDetailDataQueryVariables>

--- a/src/containers/base.media.spec.tsx
+++ b/src/containers/base.media.spec.tsx
@@ -11,7 +11,6 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { __loadRouter } from 'next/router';
-import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import videojs from 'video.js';
 

--- a/src/containers/base.spec.tsx
+++ b/src/containers/base.spec.tsx
@@ -1,7 +1,6 @@
 import { dehydrate, QueryClient, useQuery } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { __loadRouter } from 'next/router';
-import React from 'react';
 
 import { __awaitIntlMessages } from '~lib/getIntlMessages';
 import MyApp from '~pages/_app';

--- a/src/containers/base.tsx
+++ b/src/containers/base.tsx
@@ -5,7 +5,7 @@ import {
 } from '@tanstack/react-query';
 import Head from 'next/head';
 import Script from 'next/script';
-import React, { useEffect } from 'react';
+import { Component as Component_, StrictMode, useEffect } from 'react';
 
 import withIntl from '~components/HOCs/withIntl';
 import LoadingIndicator from '~components/molecules/loadingIndicator';
@@ -33,7 +33,7 @@ function Base<P>({
 	Component,
 	pageProps,
 }: {
-	Component: typeof React.Component;
+	Component: typeof Component_;
 	pageProps: P & IBaseProps;
 }): JSX.Element {
 	const { description, disableSidebar, title, canonicalUrl, dehydratedState } =
@@ -45,7 +45,7 @@ function Base<P>({
 
 	return (
 		<div className={styles.base}>
-			<React.StrictMode>
+			<StrictMode>
 				<Head>
 					{/* eslint-disable-next-line @calm/react-intl/missing-formatted-message */}
 					<title>{title ? `${title} | AudioVerse` : 'AudioVerse'}</title>
@@ -96,7 +96,7 @@ function Base<P>({
 						</AndGlobalModals>
 					</Hydrate>
 				</QueryClientProvider>
-			</React.StrictMode>
+			</StrictMode>
 		</div>
 	);
 }

--- a/src/containers/bible/__generated__/book.ts
+++ b/src/containers/bible/__generated__/book.ts
@@ -105,7 +105,8 @@ export const useInfiniteGetAudiobibleBookPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobibleBookDetailData<T>(
 	variables: ExactAlt<T, GetAudiobibleBookDetailDataQueryVariables>

--- a/src/containers/bible/__generated__/version.ts
+++ b/src/containers/bible/__generated__/version.ts
@@ -61,7 +61,8 @@ export const useInfiniteGetAudiobibleVersionDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobibleVersionData<T>(
 	variables: ExactAlt<T, GetAudiobibleVersionDataQueryVariables>

--- a/src/containers/bible/__generated__/versions.ts
+++ b/src/containers/bible/__generated__/versions.ts
@@ -64,7 +64,8 @@ export const useInfiniteGetAudiobibleVersionsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getAudiobibleVersionsData<T>(
 	variables: ExactAlt<T, GetAudiobibleVersionsDataQueryVariables>

--- a/src/containers/bible/book.spec.tsx
+++ b/src/containers/bible/book.spec.tsx
@@ -1,7 +1,6 @@
 import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { __loadRouter } from 'next/router';
-import React from 'react';
 import videojs from 'video.js';
 
 import AndMiniplayer from '~components/templates/andMiniplayer';

--- a/src/containers/bible/book.tsx
+++ b/src/containers/bible/book.tsx
@@ -28,6 +28,7 @@ import { BaseColors } from '~lib/constants';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
 import { RecordingContentType } from '~src/__generated__/graphql';
+import { Must } from '~src/types/types';
 
 import IconBack from '../../../public/img/icons/icon-back-light.svg';
 import IconBlog from '../../../public/img/icons/icon-blog-light-small.svg';

--- a/src/containers/bible/book.tsx
+++ b/src/containers/bible/book.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/bible/version.spec.tsx
+++ b/src/containers/bible/version.spec.tsx
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/react';
-import React from 'react';
 
 import * as bibleBrain from '~lib/api/bibleBrain';
 import { buildLoader } from '~lib/test/buildLoader';

--- a/src/containers/bible/version.tsx
+++ b/src/containers/bible/version.tsx
@@ -17,6 +17,7 @@ import DefinitionList, {
 import Tease from '~components/molecules/tease';
 import { IBibleVersion } from '~lib/api/bibleBrain';
 import { BaseColors } from '~lib/constants';
+import { Must } from '~src/types/types';
 
 import { GetAudiobibleVersionDataQuery } from './__generated__/version';
 import styles from './version.module.scss';

--- a/src/containers/bible/version.tsx
+++ b/src/containers/bible/version.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/bible/versions.spec.tsx
+++ b/src/containers/bible/versions.spec.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import * as bibleBrain from '~lib/api/bibleBrain';
 import { buildLoader } from '~lib/test/buildLoader';
 import renderWithProviders from '~lib/test/renderWithProviders';

--- a/src/containers/bible/versions.tsx
+++ b/src/containers/bible/versions.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/blog.tsx
+++ b/src/containers/blog.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import withFailStates from '~components/HOCs/withFailStates';
 import CardPost from '~components/molecules/card/post';
 import CardGroup from '~components/molecules/cardGroup';

--- a/src/containers/blog/__generated__/detail.ts
+++ b/src/containers/blog/__generated__/detail.ts
@@ -110,7 +110,8 @@ export const useInfiniteGetBlogDetailStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getBlogDetailData<T>(
 	variables: ExactAlt<T, GetBlogDetailDataQueryVariables>

--- a/src/containers/blog/detail.tsx
+++ b/src/containers/blog/detail.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/legacy/image';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import HorizontalRule from '~components/atoms/horizontalRule';

--- a/src/containers/blog/detail.tsx
+++ b/src/containers/blog/detail.tsx
@@ -10,6 +10,7 @@ import CardPost from '~components/molecules/card/post';
 import { BaseColors } from '~lib/constants';
 import { formatLongDate } from '~lib/date';
 import { useFormattedDuration } from '~lib/time';
+import { Must } from '~src/types/types';
 
 import { GetBlogDetailDataQuery } from './__generated__/detail';
 import styles from './detail.module.scss';

--- a/src/containers/collection/__generated__/detail.ts
+++ b/src/containers/collection/__generated__/detail.ts
@@ -218,7 +218,8 @@ export const useInfiniteGetCollectionDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCollectionDetailPageData<T>(
 	variables: ExactAlt<T, GetCollectionDetailPageDataQueryVariables>

--- a/src/containers/collection/__generated__/list.ts
+++ b/src/containers/collection/__generated__/list.ts
@@ -100,7 +100,8 @@ export const useInfiniteGetCollectionListPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCollectionListPageData<T>(
 	variables: ExactAlt<T, GetCollectionListPageDataQueryVariables>

--- a/src/containers/collection/__generated__/presenters.ts
+++ b/src/containers/collection/__generated__/presenters.ts
@@ -63,7 +63,8 @@ export const useInfiniteGetCollectionPresentersPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCollectionPresentersPageData<T>(
 	variables: ExactAlt<T, GetCollectionPresentersPageDataQueryVariables>

--- a/src/containers/collection/__generated__/sequences.ts
+++ b/src/containers/collection/__generated__/sequences.ts
@@ -64,7 +64,8 @@ export const useInfiniteGetCollectionSequencesPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCollectionSequencesPageData<T>(
 	variables: ExactAlt<T, GetCollectionSequencesPageDataQueryVariables>

--- a/src/containers/collection/__generated__/teachings.ts
+++ b/src/containers/collection/__generated__/teachings.ts
@@ -73,7 +73,8 @@ export const useInfiniteGetCollectionTeachingsPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCollectionTeachingsPageData<T>(
 	variables: ExactAlt<T, GetCollectionTeachingsPageDataQueryVariables>

--- a/src/containers/collection/detail.tsx
+++ b/src/containers/collection/detail.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/legacy/image';
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/containers/collection/detail.tsx
+++ b/src/containers/collection/detail.tsx
@@ -28,6 +28,7 @@ import { formatDateRange } from '~lib/date';
 import root from '~lib/routes';
 import { useFormattedDuration } from '~lib/time';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import ForwardIcon from '../../../public/img/icons/icon-forward-light.svg';
 import { GetCollectionDetailPageDataQuery } from './__generated__/detail';

--- a/src/containers/collection/list.tsx
+++ b/src/containers/collection/list.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import withFailStates from '~components/HOCs/withFailStates';

--- a/src/containers/collection/pivot.tsx
+++ b/src/containers/collection/pivot.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import Heading2 from '~components/atoms/heading2';
 import ButtonBack from '~components/molecules/buttonBack';

--- a/src/containers/collection/presenters.tsx
+++ b/src/containers/collection/presenters.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/collection/presenters.tsx
+++ b/src/containers/collection/presenters.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { CollectionPivotFragment } from './__generated__/pivot';
 import { GetCollectionPresentersPageDataQuery } from './__generated__/presenters';

--- a/src/containers/collection/sequences.tsx
+++ b/src/containers/collection/sequences.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/collection/sequences.tsx
+++ b/src/containers/collection/sequences.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { CollectionPivotFragment } from './__generated__/pivot';
 import { GetCollectionSequencesPageDataQuery } from './__generated__/sequences';

--- a/src/containers/collection/teachings.tsx
+++ b/src/containers/collection/teachings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/collection/teachings.tsx
+++ b/src/containers/collection/teachings.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { CollectionPivotFragment } from './__generated__/pivot';
 import { GetCollectionTeachingsPageDataQuery } from './__generated__/teachings';

--- a/src/containers/contact.tsx
+++ b/src/containers/contact.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Alert from '~components/atoms/alert';

--- a/src/containers/contact.tsx
+++ b/src/containers/contact.tsx
@@ -12,6 +12,7 @@ import Select from '~components/molecules/form/select';
 import Textarea from '~components/molecules/form/textarea';
 import { useLanguageId } from '~lib/useLanguageId';
 import { PageContactRecipient } from '~src/__generated__/graphql';
+import { Must } from '~src/types/types';
 
 import { useSubmitContactPageMutation } from './__generated__/contact';
 import styles from './contact.module.scss';

--- a/src/containers/discover/__generated__/collections.ts
+++ b/src/containers/discover/__generated__/collections.ts
@@ -130,7 +130,8 @@ export const useInfiniteGetDiscoverCollectionsPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getDiscoverCollectionsPageData<T>(
 	variables: ExactAlt<T, GetDiscoverCollectionsPageDataQueryVariables>

--- a/src/containers/discover/__generated__/index.ts
+++ b/src/containers/discover/__generated__/index.ts
@@ -385,7 +385,8 @@ export const useInfiniteGetDiscoverBlogPostsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getDiscoverRecentTeachings<T>(
 	variables: ExactAlt<T, GetDiscoverRecentTeachingsQueryVariables>

--- a/src/containers/discover/collections.tsx
+++ b/src/containers/discover/collections.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/discover/index.section.blogPosts.tsx
+++ b/src/containers/discover/index.section.blogPosts.tsx
@@ -1,5 +1,4 @@
 import { Maybe } from 'graphql/jsutils/Maybe';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import { CardPostFragment } from '~src/components/molecules/card/__generated__/post';

--- a/src/containers/discover/index.section.conferences.tsx
+++ b/src/containers/discover/index.section.conferences.tsx
@@ -1,5 +1,4 @@
 import { Maybe } from 'graphql/jsutils/Maybe';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import CardCollection from '~src/components/molecules/card/collection';

--- a/src/containers/discover/index.section.featuredTeachings.tsx
+++ b/src/containers/discover/index.section.featuredTeachings.tsx
@@ -1,5 +1,4 @@
 import { Maybe } from 'graphql/jsutils/Maybe';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import { CardRecordingFragment } from '~src/components/molecules/card/__generated__/recording';

--- a/src/containers/discover/index.section.recentTeachings.tsx
+++ b/src/containers/discover/index.section.recentTeachings.tsx
@@ -1,5 +1,4 @@
 import { Maybe } from 'graphql/jsutils/Maybe';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import { CardRecordingFragment } from '~src/components/molecules/card/__generated__/recording';

--- a/src/containers/discover/index.section.storySeasons.tsx
+++ b/src/containers/discover/index.section.storySeasons.tsx
@@ -1,5 +1,4 @@
 import { Maybe } from 'graphql/jsutils/Maybe';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import CardSequence from '~src/components/molecules/card/sequence';

--- a/src/containers/discover/index.section.trendingTeachings.tsx
+++ b/src/containers/discover/index.section.trendingTeachings.tsx
@@ -1,5 +1,4 @@
 import { Maybe } from 'graphql/jsutils/Maybe';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import { CardRecordingFragment } from '~src/components/molecules/card/__generated__/recording';

--- a/src/containers/discover/index.section.tsx
+++ b/src/containers/discover/index.section.tsx
@@ -1,6 +1,6 @@
 import { UseInfiniteQueryResult } from '@tanstack/react-query';
 import { Maybe } from 'graphql/jsutils/Maybe';
-import React, { useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/discover/index.slider.spec.tsx
+++ b/src/containers/discover/index.slider.spec.tsx
@@ -78,14 +78,11 @@ describe('Slider', () => {
 	});
 
 	it('calls onIndexChange', async () => {
-		const items = [
-			<div key="1">1</div>,
-			<div key="2">2</div>,
-		] as any as HTMLElement[];
+		const items = [<div key="1">1</div>, <div key="2">2</div>];
 
 		__swiper.isEnd = false;
 		__swiper.realIndex = 1;
-		__swiper.slides = items;
+		__swiper.slides = items as any;
 
 		const onIndexChange = jest.fn();
 

--- a/src/containers/discover/index.slider.spec.tsx
+++ b/src/containers/discover/index.slider.spec.tsx
@@ -1,6 +1,5 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 
 import { __eventHandlers, __runHandlers, __swiper } from '~lib/swiper';
 import useElementWidth from '~src/lib/hooks/useElementWidth';

--- a/src/containers/discover/index.slider.tsx
+++ b/src/containers/discover/index.slider.tsx
@@ -1,5 +1,5 @@
 import dynamic from 'next/dynamic';
-import React, { startTransition, useMemo, useState } from 'react';
+import { startTransition, useMemo, useState } from 'react';
 import type Swiper from 'swiper';
 
 import IconBack from '~public/img/icons/icon-back-light.svg';

--- a/src/containers/discover/index.tsx
+++ b/src/containers/discover/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import BlogPosts from './index.section.blogPosts';
 import Conferences from './index.section.conferences';
 import FeaturedTeachings from './index.section.featuredTeachings';

--- a/src/containers/give.tsx
+++ b/src/containers/give.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, { SyntheticEvent } from 'react';
+import { SyntheticEvent } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/home.tsx
+++ b/src/containers/home.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import Image from 'next/legacy/image';
 import Link from 'next/link';
-import React, { ReactNode, useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/library/__generated__/history.ts
+++ b/src/containers/library/__generated__/history.ts
@@ -76,7 +76,8 @@ export const useInfiniteGetLibraryHistoryPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getLibraryHistoryPageData<T>(
 	variables: ExactAlt<T, GetLibraryHistoryPageDataQueryVariables>

--- a/src/containers/library/__generated__/library.ts
+++ b/src/containers/library/__generated__/library.ts
@@ -99,7 +99,8 @@ export const useInfiniteGetLibraryDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getLibraryData<T>(
 	variables: ExactAlt<T, GetLibraryDataQueryVariables>

--- a/src/containers/library/history.tsx
+++ b/src/containers/library/history.tsx
@@ -1,5 +1,5 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import React from 'react';
+import { Fragment } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import withAuthGuard from '~components/HOCs/withAuthGuard';
@@ -67,7 +67,7 @@ function LibraryHistory({ language }: ILibraryHistoryProps): JSX.Element {
 				<>
 					<CardGroup>
 						{data?.pages?.map((group, i) => (
-							<React.Fragment key={i}>
+							<Fragment key={i}>
 								{(group.me?.user.downloadHistory.nodes || []).map(
 									({ recording }) => (
 										<CardRecording
@@ -76,7 +76,7 @@ function LibraryHistory({ language }: ILibraryHistoryProps): JSX.Element {
 										/>
 									)
 								)}
-							</React.Fragment>
+							</Fragment>
 						))}
 					</CardGroup>
 					{showLoadMore && (

--- a/src/containers/library/library.tsx
+++ b/src/containers/library/library.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import withAuthGuard from '~components/HOCs/withAuthGuard';

--- a/src/containers/library/loggedOut.tsx
+++ b/src/containers/library/loggedOut.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Alert from '~components/atoms/alert';

--- a/src/containers/library/playlist/__generated__/detail.ts
+++ b/src/containers/library/playlist/__generated__/detail.ts
@@ -69,7 +69,8 @@ export const useInfiniteGetLibraryPlaylistPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getLibraryPlaylistPageData<T>(
 	variables: ExactAlt<T, GetLibraryPlaylistPageDataQueryVariables>

--- a/src/containers/library/playlist/__generated__/list.ts
+++ b/src/containers/library/playlist/__generated__/list.ts
@@ -67,7 +67,8 @@ export const useInfiniteGetLibraryPlaylistsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getLibraryPlaylistsData<T>(
 	variables: ExactAlt<T, GetLibraryPlaylistsDataQueryVariables>

--- a/src/containers/library/playlist/detail.tsx
+++ b/src/containers/library/playlist/detail.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/containers/library/playlist/detail.tsx
+++ b/src/containers/library/playlist/detail.tsx
@@ -16,6 +16,7 @@ import Tease from '~components/molecules/tease';
 import TypeLockup from '~components/molecules/typeLockup';
 import { BaseColors } from '~lib/constants';
 import { formatLongDateTime } from '~lib/date';
+import { Must } from '~src/types/types';
 
 import ListIcon from '../../../../public/img/icons/fa-list.svg';
 import LikeActiveIcon from '../../../../public/img/icons/icon-like-active.svg';

--- a/src/containers/library/playlist/list.tsx
+++ b/src/containers/library/playlist/list.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import InfoBox from '~components/atoms/infoBox';

--- a/src/containers/page/__generated__/detail.ts
+++ b/src/containers/page/__generated__/detail.ts
@@ -93,7 +93,8 @@ export const useInfiniteGetCustomDetailPageStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getCustomDetailPageData<T>(
 	variables: ExactAlt<T, GetCustomDetailPageDataQueryVariables>

--- a/src/containers/page/detail.tsx
+++ b/src/containers/page/detail.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Heading1 from '~components/atoms/heading1';
 import withFailStates from '~components/HOCs/withFailStates';
 import ContentWidthLimiter from '~components/molecules/contentWidthLimiter';
+import { Must } from '~src/types/types';
 
 import { GetCustomDetailPageDataQuery } from './__generated__/detail';
 

--- a/src/containers/page/detail.tsx
+++ b/src/containers/page/detail.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Heading1 from '~components/atoms/heading1';
 import withFailStates from '~components/HOCs/withFailStates';
 import ContentWidthLimiter from '~components/molecules/contentWidthLimiter';

--- a/src/containers/presenter/__generated__/appears.ts
+++ b/src/containers/presenter/__generated__/appears.ts
@@ -65,7 +65,8 @@ export const useInfiniteGetPresenterAppearsPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterAppearsPageData<T>(
 	variables: ExactAlt<T, GetPresenterAppearsPageDataQueryVariables>

--- a/src/containers/presenter/__generated__/detail.ts
+++ b/src/containers/presenter/__generated__/detail.ts
@@ -199,7 +199,8 @@ export const useInfiniteGetPresenterDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterDetailPageData<T>(
 	variables: ExactAlt<T, GetPresenterDetailPageDataQueryVariables>

--- a/src/containers/presenter/__generated__/recordings.ts
+++ b/src/containers/presenter/__generated__/recordings.ts
@@ -125,7 +125,8 @@ export const useInfiniteGetPresenterRecordingsFeedDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterRecordingsPageData<T>(
 	variables: ExactAlt<T, GetPresenterRecordingsPageDataQueryVariables>

--- a/src/containers/presenter/__generated__/sequences.ts
+++ b/src/containers/presenter/__generated__/sequences.ts
@@ -67,7 +67,8 @@ export const useInfiniteGetPresenterSequencesPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterSequencesPageData<T>(
 	variables: ExactAlt<T, GetPresenterSequencesPageDataQueryVariables>

--- a/src/containers/presenter/__generated__/top.ts
+++ b/src/containers/presenter/__generated__/top.ts
@@ -73,7 +73,8 @@ export const useInfiniteGetPresenterTopPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterTopPageData<T>(
 	variables: ExactAlt<T, GetPresenterTopPageDataQueryVariables>

--- a/src/containers/presenter/appears.tsx
+++ b/src/containers/presenter/appears.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { GetPresenterAppearsPageDataQuery } from './__generated__/appears';
 import { PresenterPivotFragment } from './__generated__/pivot';

--- a/src/containers/presenter/appears.tsx
+++ b/src/containers/presenter/appears.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/presenter/detail.tsx
+++ b/src/containers/presenter/detail.tsx
@@ -25,6 +25,7 @@ import { useIsPersonFavorited } from '~lib/api/useIsPersonFavorited';
 import { BaseColors } from '~lib/constants';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import ForwardIcon from '../../../public/img/icons/icon-forward-light.svg';
 import { GetPresenterDetailPageDataQuery } from './__generated__/detail';

--- a/src/containers/presenter/detail.tsx
+++ b/src/containers/presenter/detail.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/containers/presenter/list/__generated__/all.ts
+++ b/src/containers/presenter/list/__generated__/all.ts
@@ -66,7 +66,8 @@ export const useInfiniteGetPresenterListAllPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterListAllPageData<T>(
 	variables: ExactAlt<T, GetPresenterListAllPageDataQueryVariables>

--- a/src/containers/presenter/list/__generated__/letter.ts
+++ b/src/containers/presenter/list/__generated__/letter.ts
@@ -57,7 +57,8 @@ export const useInfiniteGetPresenterListLetterPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPresenterListLetterPageData<T>(
 	variables: ExactAlt<T, GetPresenterListLetterPageDataQueryVariables>

--- a/src/containers/presenter/list/__generated__/list.ts
+++ b/src/containers/presenter/list/__generated__/list.ts
@@ -57,7 +57,8 @@ export const useInfiniteGetPersonListLetterCountsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getPersonListLetterCounts<T>(
 	variables: ExactAlt<T, GetPersonListLetterCountsQueryVariables>

--- a/src/containers/presenter/list/all.tsx
+++ b/src/containers/presenter/list/all.tsx
@@ -1,5 +1,5 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useIntl } from 'react-intl';
 
 import { fetchApi } from '~lib/api/fetchApi';

--- a/src/containers/presenter/list/letter.tsx
+++ b/src/containers/presenter/list/letter.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import withFailStates from '~components/HOCs/withFailStates';
 
 import Presenters, { PresentersProps } from './list';

--- a/src/containers/presenter/list/list.tsx
+++ b/src/containers/presenter/list/list.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/presenter/pivot.tsx
+++ b/src/containers/presenter/pivot.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import Heading2 from '~components/atoms/heading2';
 import RoundImage from '~components/atoms/roundImage';

--- a/src/containers/presenter/recordings.tsx
+++ b/src/containers/presenter/recordings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/presenter/recordings.tsx
+++ b/src/containers/presenter/recordings.tsx
@@ -11,6 +11,7 @@ import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import { PresenterPivotFragment } from './__generated__/pivot';
 import { GetPresenterRecordingsPageDataQuery } from './__generated__/recordings';

--- a/src/containers/presenter/sequences.tsx
+++ b/src/containers/presenter/sequences.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/presenter/sequences.tsx
+++ b/src/containers/presenter/sequences.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { PresenterPivotFragment } from './__generated__/pivot';
 import { GetPresenterSequencesPageDataQuery } from './__generated__/sequences';

--- a/src/containers/presenter/top.tsx
+++ b/src/containers/presenter/top.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/presenter/top.tsx
+++ b/src/containers/presenter/top.tsx
@@ -6,6 +6,7 @@ import withFailStates from '~components/HOCs/withFailStates';
 import CardRecording from '~components/molecules/card/recording';
 import CardGroup from '~components/molecules/cardGroup';
 import { BaseColors } from '~lib/constants';
+import { Must } from '~src/types/types';
 
 import { PresenterPivotFragment } from './__generated__/pivot';
 import { GetPresenterTopPageDataQuery } from './__generated__/top';

--- a/src/containers/release/__generated__/detail.ts
+++ b/src/containers/release/__generated__/detail.ts
@@ -123,7 +123,8 @@ export const useSubmitMediaReleaseFormMutation = <
       (variables?: SubmitMediaReleaseFormMutationVariables) => graphqlFetcher<SubmitMediaReleaseFormMutation, SubmitMediaReleaseFormMutationVariables>(SubmitMediaReleaseFormDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getMediaReleaseFormsPageData<T>(
 	variables: ExactAlt<T, GetMediaReleaseFormsPageDataQueryVariables>

--- a/src/containers/release/detail.tsx
+++ b/src/containers/release/detail.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Alert from '~components/atoms/alert';

--- a/src/containers/release/detail.tsx
+++ b/src/containers/release/detail.tsx
@@ -9,6 +9,7 @@ import Button from '~components/molecules/button';
 import ContentWidthLimiter from '~components/molecules/contentWidthLimiter';
 import Input from '~components/molecules/form/input';
 import Textarea from '~components/molecules/form/textarea';
+import { Must } from '~src/types/types';
 
 import {
 	GetMediaReleaseFormsPageDataQuery,

--- a/src/containers/search/__generated__/collections.ts
+++ b/src/containers/search/__generated__/collections.ts
@@ -53,7 +53,8 @@ export const useInfiniteGetSearchResultsCollectionsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchResultsCollections<T>(
 	variables: ExactAlt<T, GetSearchResultsCollectionsQueryVariables>

--- a/src/containers/search/__generated__/persons.ts
+++ b/src/containers/search/__generated__/persons.ts
@@ -53,7 +53,8 @@ export const useInfiniteGetSearchResultsPersonsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchResultsPersons<T>(
 	variables: ExactAlt<T, GetSearchResultsPersonsQueryVariables>

--- a/src/containers/search/__generated__/sequences.ts
+++ b/src/containers/search/__generated__/sequences.ts
@@ -55,7 +55,8 @@ export const useInfiniteGetSearchResultsSequencesQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchResultsSequences<T>(
 	variables: ExactAlt<T, GetSearchResultsSequencesQueryVariables>

--- a/src/containers/search/__generated__/sponsors.ts
+++ b/src/containers/search/__generated__/sponsors.ts
@@ -53,7 +53,8 @@ export const useInfiniteGetSearchResultsSponsorsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchResultsSponsors<T>(
 	variables: ExactAlt<T, GetSearchResultsSponsorsQueryVariables>

--- a/src/containers/search/__generated__/teachings.ts
+++ b/src/containers/search/__generated__/teachings.ts
@@ -63,7 +63,8 @@ export const useInfiniteGetSearchResultsRecordingsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSearchResultsRecordings<T>(
 	variables: ExactAlt<T, GetSearchResultsRecordingsQueryVariables>

--- a/src/containers/search/collections.tsx
+++ b/src/containers/search/collections.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import withFailStates from '~components/HOCs/withFailStates';

--- a/src/containers/search/persons.tsx
+++ b/src/containers/search/persons.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import withFailStates from '~components/HOCs/withFailStates';

--- a/src/containers/search/sequences.tsx
+++ b/src/containers/search/sequences.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import withFailStates from '~components/HOCs/withFailStates';

--- a/src/containers/search/sponsors.tsx
+++ b/src/containers/search/sponsors.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import withFailStates from '~components/HOCs/withFailStates';

--- a/src/containers/search/teachings.tsx
+++ b/src/containers/search/teachings.tsx
@@ -1,5 +1,4 @@
 import { useRouter } from 'next/router';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import withFailStates from '~components/HOCs/withFailStates';

--- a/src/containers/series/__generated__/detail.ts
+++ b/src/containers/series/__generated__/detail.ts
@@ -155,7 +155,8 @@ export const useInfiniteGetSeriesDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSeriesDetailPageData<T>(
 	variables: ExactAlt<T, GetSeriesDetailPageDataQueryVariables>

--- a/src/containers/series/__generated__/list.ts
+++ b/src/containers/series/__generated__/list.ts
@@ -102,7 +102,8 @@ export const useInfiniteGetSeriesListPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSeriesListPageData<T>(
 	variables: ExactAlt<T, GetSeriesListPageDataQueryVariables>

--- a/src/containers/series/list.tsx
+++ b/src/containers/series/list.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import withFailStates from '~components/HOCs/withFailStates';

--- a/src/containers/sermon/__generated__/detail.ts
+++ b/src/containers/sermon/__generated__/detail.ts
@@ -107,7 +107,8 @@ export const useInfiniteGetSermonDetailStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSermonDetailData<T>(
 	variables: ExactAlt<T, GetSermonDetailDataQueryVariables>

--- a/src/containers/sermon/__generated__/list.ts
+++ b/src/containers/sermon/__generated__/list.ts
@@ -161,7 +161,8 @@ export const useInfiniteGetSermonListPagePathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSermonListPageData<T>(
 	variables: ExactAlt<T, GetSermonListPageDataQueryVariables>

--- a/src/containers/sermon/__generated__/trending.ts
+++ b/src/containers/sermon/__generated__/trending.ts
@@ -65,7 +65,8 @@ export const useInfiniteGetTrendingTeachingsPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getTrendingTeachingsPageData<T>(
 	variables: ExactAlt<T, GetTrendingTeachingsPageDataQueryVariables>

--- a/src/containers/sermon/detail.spec.tsx
+++ b/src/containers/sermon/detail.spec.tsx
@@ -10,7 +10,6 @@ import {
 import userEvent from '@testing-library/user-event';
 import { when } from 'jest-when';
 import { __loadQuery, __loadRouter } from 'next/router';
-import React from 'react';
 import ReactTestUtils from 'react-dom/test-utils';
 import videojs from 'video.js';
 

--- a/src/containers/sermon/embed.tsx
+++ b/src/containers/sermon/embed.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/sermon/embed.tsx
+++ b/src/containers/sermon/embed.tsx
@@ -9,6 +9,7 @@ import Player from '~components/molecules/player';
 import AndMiniplayer from '~components/templates/andMiniplayer';
 import { getRecordingTypeTheme } from '~lib/getRecordingTheme';
 import { getSequenceTypeTheme } from '~lib/getSequenceType';
+import { Must } from '~src/types/types';
 
 import Logo from '../../../public/img/logo-small.svg';
 import { GetSermonDetailDataQuery } from './__generated__/detail';

--- a/src/containers/sermon/list.tsx
+++ b/src/containers/sermon/list.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import withFailStates from '~components/HOCs/withFailStates';

--- a/src/containers/sermon/trending.tsx
+++ b/src/containers/sermon/trending.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/sermon/trending.tsx
+++ b/src/containers/sermon/trending.tsx
@@ -9,6 +9,7 @@ import CardGroup from '~components/molecules/cardGroup';
 import RecordingHasVideoFilter from '~components/molecules/recordingHasVideoFilter';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import { GetTrendingTeachingsPageDataQuery } from './__generated__/trending';
 import styles from './trending.module.scss';

--- a/src/containers/song/__generated__/detail.ts
+++ b/src/containers/song/__generated__/detail.ts
@@ -106,7 +106,8 @@ export const useInfiniteGetSongDetailStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSongDetailData<T>(
 	variables: ExactAlt<T, GetSongDetailDataQueryVariables>

--- a/src/containers/song/albums/__generated__/detail.ts
+++ b/src/containers/song/albums/__generated__/detail.ts
@@ -152,7 +152,8 @@ export const useInfiniteGetSongAlbumsDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSongAlbumsDetailPageData<T>(
 	variables: ExactAlt<T, GetSongAlbumsDetailPageDataQueryVariables>

--- a/src/containers/song/albums/__generated__/list.ts
+++ b/src/containers/song/albums/__generated__/list.ts
@@ -85,7 +85,8 @@ export const useInfiniteGetSongAlbumsListPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSongAlbumsListPageData<T>(
 	variables: ExactAlt<T, GetSongAlbumsListPageDataQueryVariables>

--- a/src/containers/song/albums/list.tsx
+++ b/src/containers/song/albums/list.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/song/books/__generated__/detail.ts
+++ b/src/containers/song/books/__generated__/detail.ts
@@ -63,7 +63,8 @@ export const useInfiniteGetSongBooksDetailPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSongBooksDetailPageData<T>(
 	variables: ExactAlt<T, GetSongBooksDetailPageDataQueryVariables>

--- a/src/containers/song/books/__generated__/track.ts
+++ b/src/containers/song/books/__generated__/track.ts
@@ -74,7 +74,8 @@ export const useInfiniteGetBookSongDetailDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getBookSongDetailData<T>(
 	variables: ExactAlt<T, GetBookSongDetailDataQueryVariables>

--- a/src/containers/song/books/detail.tsx
+++ b/src/containers/song/books/detail.tsx
@@ -1,5 +1,4 @@
 import startCase from 'lodash/startCase';
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/containers/song/books/track.tsx
+++ b/src/containers/song/books/track.tsx
@@ -4,6 +4,7 @@ import withFailStates from '~components/HOCs/withFailStates';
 import { Recording } from '~components/organisms/recording';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import { GetBookSongDetailDataQuery } from './__generated__/track';
 

--- a/src/containers/song/books/track.tsx
+++ b/src/containers/song/books/track.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import withFailStates from '~components/HOCs/withFailStates';
 import { Recording } from '~components/organisms/recording';
 import root from '~lib/routes';

--- a/src/containers/sponsor/__generated__/conferences.ts
+++ b/src/containers/sponsor/__generated__/conferences.ts
@@ -108,7 +108,8 @@ export const useInfiniteGetSponsorConferencesPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorConferencesPageData<T>(
 	variables: ExactAlt<T, GetSponsorConferencesPageDataQueryVariables>

--- a/src/containers/sponsor/__generated__/detail.ts
+++ b/src/containers/sponsor/__generated__/detail.ts
@@ -149,7 +149,8 @@ export const useInfiniteGetSponsorDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorDetailPageData<T>(
 	variables: ExactAlt<T, GetSponsorDetailPageDataQueryVariables>

--- a/src/containers/sponsor/__generated__/series.ts
+++ b/src/containers/sponsor/__generated__/series.ts
@@ -110,7 +110,8 @@ export const useInfiniteGetSponsorSeriesPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorSeriesPageData<T>(
 	variables: ExactAlt<T, GetSponsorSeriesPageDataQueryVariables>

--- a/src/containers/sponsor/__generated__/teachings.ts
+++ b/src/containers/sponsor/__generated__/teachings.ts
@@ -165,7 +165,8 @@ export const useInfiniteGetSponsorTeachingsPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorTeachingsPageData<T>(
 	variables: ExactAlt<T, GetSponsorTeachingsPageDataQueryVariables>

--- a/src/containers/sponsor/conferences.tsx
+++ b/src/containers/sponsor/conferences.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { GetSponsorConferencesPageDataQuery } from './__generated__/conferences';
 import { SponsorPivotFragment } from './__generated__/pivot';

--- a/src/containers/sponsor/conferences.tsx
+++ b/src/containers/sponsor/conferences.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/sponsor/detail.tsx
+++ b/src/containers/sponsor/detail.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading2 from '~components/atoms/heading2';

--- a/src/containers/sponsor/detail.tsx
+++ b/src/containers/sponsor/detail.tsx
@@ -25,6 +25,7 @@ import { useIsSponsorFavorited } from '~lib/api/useIsSponsorFavorited';
 import { BaseColors } from '~lib/constants';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import ForwardIcon from '../../../public/img/icons/icon-forward-light.svg';
 import { GetSponsorDetailPageDataQuery } from './__generated__/detail';

--- a/src/containers/sponsor/list/__generated__/all.ts
+++ b/src/containers/sponsor/list/__generated__/all.ts
@@ -57,7 +57,8 @@ export const useInfiniteGetSponsorListAllPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorListAllPageData<T>(
 	variables: ExactAlt<T, GetSponsorListAllPageDataQueryVariables>

--- a/src/containers/sponsor/list/__generated__/letter.ts
+++ b/src/containers/sponsor/list/__generated__/letter.ts
@@ -57,7 +57,8 @@ export const useInfiniteGetSponsorListLetterPageDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorListLetterPageData<T>(
 	variables: ExactAlt<T, GetSponsorListLetterPageDataQueryVariables>

--- a/src/containers/sponsor/list/__generated__/list.ts
+++ b/src/containers/sponsor/list/__generated__/list.ts
@@ -55,7 +55,8 @@ export const useInfiniteGetSponsorListLetterCountsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getSponsorListLetterCounts<T>(
 	variables: ExactAlt<T, GetSponsorListLetterCountsQueryVariables>

--- a/src/containers/sponsor/list/all.tsx
+++ b/src/containers/sponsor/list/all.tsx
@@ -1,5 +1,5 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useIntl } from 'react-intl';
 
 import { fetchApi } from '~lib/api/fetchApi';

--- a/src/containers/sponsor/list/letter.tsx
+++ b/src/containers/sponsor/list/letter.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import withFailStates from '~components/HOCs/withFailStates';
 
 import Sponsors, { SponsorsProps } from './list';

--- a/src/containers/sponsor/list/list.tsx
+++ b/src/containers/sponsor/list/list.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/containers/sponsor/pivot.tsx
+++ b/src/containers/sponsor/pivot.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import Heading2 from '~components/atoms/heading2';
 import RoundImage from '~components/atoms/roundImage';

--- a/src/containers/sponsor/series.tsx
+++ b/src/containers/sponsor/series.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/sponsor/series.tsx
+++ b/src/containers/sponsor/series.tsx
@@ -9,6 +9,7 @@ import Pagination from '~components/molecules/pagination';
 import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
+import { Must } from '~src/types/types';
 
 import { SponsorPivotFragment } from './__generated__/pivot';
 import { GetSponsorSeriesPageDataQuery } from './__generated__/series';

--- a/src/containers/sponsor/teachings.tsx
+++ b/src/containers/sponsor/teachings.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import LineHeading from '~components/atoms/lineHeading';

--- a/src/containers/sponsor/teachings.tsx
+++ b/src/containers/sponsor/teachings.tsx
@@ -11,6 +11,7 @@ import { BaseColors } from '~lib/constants';
 import { PaginatedProps } from '~lib/getPaginatedStaticProps';
 import root from '~lib/routes';
 import useLanguageRoute from '~lib/useLanguageRoute';
+import { Must } from '~src/types/types';
 
 import { SponsorPivotFragment } from './__generated__/pivot';
 import { GetSponsorTeachingsPageDataQuery } from './__generated__/teachings';

--- a/src/containers/story/__generated__/detail.ts
+++ b/src/containers/story/__generated__/detail.ts
@@ -106,7 +106,8 @@ export const useInfiniteGetStoryDetailStaticPathsQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getStoryDetailData<T>(
 	variables: ExactAlt<T, GetStoryDetailDataQueryVariables>

--- a/src/containers/story/albums/__generated__/detail.ts
+++ b/src/containers/story/albums/__generated__/detail.ts
@@ -162,7 +162,8 @@ export const useInfiniteGetStoryAlbumDetailPathsDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getStoryAlbumDetailPageData<T>(
 	variables: ExactAlt<T, GetStoryAlbumDetailPageDataQueryVariables>

--- a/src/containers/story/albums/__generated__/list.ts
+++ b/src/containers/story/albums/__generated__/list.ts
@@ -97,7 +97,8 @@ export const useInfiniteGetStoriesAlbumsPathDataQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getStoriesAlbumsPageData<T>(
 	variables: ExactAlt<T, GetStoriesAlbumsPageDataQueryVariables>

--- a/src/containers/story/albums/list.tsx
+++ b/src/containers/story/albums/list.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import CardSequence from '~components/molecules/card/sequence';

--- a/src/containers/testimonies.spec.tsx
+++ b/src/containers/testimonies.spec.tsx
@@ -1,5 +1,4 @@
 import { when } from 'jest-when';
-import React from 'react';
 
 import { fetchApi } from '~lib/api/fetchApi';
 import { ENTRIES_PER_PAGE } from '~lib/constants';

--- a/src/containers/testimonies.tsx
+++ b/src/containers/testimonies.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import Heading1 from '~components/atoms/heading1';

--- a/src/lib/__mocks__/swiper.tsx
+++ b/src/lib/__mocks__/swiper.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import * as swiper from 'swiper';
 import { SwiperEvents } from 'swiper/types';
 import { ValueOf } from 'type-fest';

--- a/src/lib/api/__generated__/bibleContent.ts
+++ b/src/lib/api/__generated__/bibleContent.ts
@@ -50,7 +50,8 @@ export const useInfiniteGetBibleBookContentQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function getBibleBookContent<T>(
 	variables: ExactAlt<T, GetBibleBookContentQueryVariables>

--- a/src/lib/api/__generated__/collectionFavorite.ts
+++ b/src/lib/api/__generated__/collectionFavorite.ts
@@ -26,7 +26,8 @@ export const useCollectionFavoriteMutation = <
       (variables?: CollectionFavoriteMutationVariables) => graphqlFetcher<CollectionFavoriteMutation, CollectionFavoriteMutationVariables>(CollectionFavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function collectionFavorite<T>(
 	variables: ExactAlt<T, CollectionFavoriteMutationVariables>

--- a/src/lib/api/__generated__/collectionIsFavorited.ts
+++ b/src/lib/api/__generated__/collectionIsFavorited.ts
@@ -45,7 +45,8 @@ export const useInfiniteCollectionIsFavoritedQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function collectionIsFavorited<T>(
 	variables: ExactAlt<T, CollectionIsFavoritedQueryVariables>

--- a/src/lib/api/__generated__/collectionUnfavorite.ts
+++ b/src/lib/api/__generated__/collectionUnfavorite.ts
@@ -26,7 +26,8 @@ export const useCollectionUnfavoriteMutation = <
       (variables?: CollectionUnfavoriteMutationVariables) => graphqlFetcher<CollectionUnfavoriteMutation, CollectionUnfavoriteMutationVariables>(CollectionUnfavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function collectionUnfavorite<T>(
 	variables: ExactAlt<T, CollectionUnfavoriteMutationVariables>

--- a/src/lib/api/__generated__/login.ts
+++ b/src/lib/api/__generated__/login.ts
@@ -32,7 +32,8 @@ export const useLoginMutation = <
       (variables?: LoginMutationVariables) => graphqlFetcher<LoginMutation, LoginMutationVariables>(LoginDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function login<T>(
 	variables: ExactAlt<T, LoginMutationVariables>

--- a/src/lib/api/__generated__/personFavorite.ts
+++ b/src/lib/api/__generated__/personFavorite.ts
@@ -26,7 +26,8 @@ export const usePersonFavoriteMutation = <
       (variables?: PersonFavoriteMutationVariables) => graphqlFetcher<PersonFavoriteMutation, PersonFavoriteMutationVariables>(PersonFavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function personFavorite<T>(
 	variables: ExactAlt<T, PersonFavoriteMutationVariables>

--- a/src/lib/api/__generated__/personIsFavorited.ts
+++ b/src/lib/api/__generated__/personIsFavorited.ts
@@ -44,7 +44,8 @@ export const useInfinitePersonIsFavoritedQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function personIsFavorited<T>(
 	variables: ExactAlt<T, PersonIsFavoritedQueryVariables>

--- a/src/lib/api/__generated__/personUnfavorite.ts
+++ b/src/lib/api/__generated__/personUnfavorite.ts
@@ -26,7 +26,8 @@ export const usePersonUnfavoriteMutation = <
       (variables?: PersonUnfavoriteMutationVariables) => graphqlFetcher<PersonUnfavoriteMutation, PersonUnfavoriteMutationVariables>(PersonUnfavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function personUnfavorite<T>(
 	variables: ExactAlt<T, PersonUnfavoriteMutationVariables>

--- a/src/lib/api/__generated__/recordingFavorite.ts
+++ b/src/lib/api/__generated__/recordingFavorite.ts
@@ -26,7 +26,8 @@ export const useRecordingFavoriteMutation = <
       (variables?: RecordingFavoriteMutationVariables) => graphqlFetcher<RecordingFavoriteMutation, RecordingFavoriteMutationVariables>(RecordingFavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function recordingFavorite<T>(
 	variables: ExactAlt<T, RecordingFavoriteMutationVariables>

--- a/src/lib/api/__generated__/recordingIsFavorited.ts
+++ b/src/lib/api/__generated__/recordingIsFavorited.ts
@@ -44,7 +44,8 @@ export const useInfiniteRecordingIsFavoritedQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function recordingIsFavorited<T>(
 	variables: ExactAlt<T, RecordingIsFavoritedQueryVariables>

--- a/src/lib/api/__generated__/recordingUnfavorite.ts
+++ b/src/lib/api/__generated__/recordingUnfavorite.ts
@@ -26,7 +26,8 @@ export const useRecordingUnfavoriteMutation = <
       (variables?: RecordingUnfavoriteMutationVariables) => graphqlFetcher<RecordingUnfavoriteMutation, RecordingUnfavoriteMutationVariables>(RecordingUnfavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function recordingUnfavorite<T>(
 	variables: ExactAlt<T, RecordingUnfavoriteMutationVariables>

--- a/src/lib/api/__generated__/sequenceFavorite.ts
+++ b/src/lib/api/__generated__/sequenceFavorite.ts
@@ -26,7 +26,8 @@ export const useSequenceFavoriteMutation = <
       (variables?: SequenceFavoriteMutationVariables) => graphqlFetcher<SequenceFavoriteMutation, SequenceFavoriteMutationVariables>(SequenceFavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sequenceFavorite<T>(
 	variables: ExactAlt<T, SequenceFavoriteMutationVariables>

--- a/src/lib/api/__generated__/sequenceIsFavorited.ts
+++ b/src/lib/api/__generated__/sequenceIsFavorited.ts
@@ -50,7 +50,8 @@ export const useInfiniteSequenceIsFavoritedQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sequenceIsFavorited<T>(
 	variables: ExactAlt<T, SequenceIsFavoritedQueryVariables>

--- a/src/lib/api/__generated__/sequenceUnfavorite.ts
+++ b/src/lib/api/__generated__/sequenceUnfavorite.ts
@@ -26,7 +26,8 @@ export const useSequenceUnfavoriteMutation = <
       (variables?: SequenceUnfavoriteMutationVariables) => graphqlFetcher<SequenceUnfavoriteMutation, SequenceUnfavoriteMutationVariables>(SequenceUnfavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sequenceUnfavorite<T>(
 	variables: ExactAlt<T, SequenceUnfavoriteMutationVariables>

--- a/src/lib/api/__generated__/sponsorFavorite.ts
+++ b/src/lib/api/__generated__/sponsorFavorite.ts
@@ -26,7 +26,8 @@ export const useSponsorFavoriteMutation = <
       (variables?: SponsorFavoriteMutationVariables) => graphqlFetcher<SponsorFavoriteMutation, SponsorFavoriteMutationVariables>(SponsorFavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sponsorFavorite<T>(
 	variables: ExactAlt<T, SponsorFavoriteMutationVariables>

--- a/src/lib/api/__generated__/sponsorIsFavorited.ts
+++ b/src/lib/api/__generated__/sponsorIsFavorited.ts
@@ -44,7 +44,8 @@ export const useInfiniteSponsorIsFavoritedQuery = <
       options
     )};
 
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sponsorIsFavorited<T>(
 	variables: ExactAlt<T, SponsorIsFavoritedQueryVariables>

--- a/src/lib/api/__generated__/sponsorUnfavorite.ts
+++ b/src/lib/api/__generated__/sponsorUnfavorite.ts
@@ -26,7 +26,8 @@ export const useSponsorUnfavoriteMutation = <
       (variables?: SponsorUnfavoriteMutationVariables) => graphqlFetcher<SponsorUnfavoriteMutation, SponsorUnfavoriteMutationVariables>(SponsorUnfavoriteDocument, variables)(),
       options
     );
-import { fetchApi } from '~lib/api/fetchApi' 
+import { fetchApi } from '~lib/api/fetchApi';
+import { ExactAlt } from '~src/types/types';
 
 export async function sponsorUnfavorite<T>(
 	variables: ExactAlt<T, SponsorUnfavoriteMutationVariables>

--- a/src/lib/api/useLogout.spec.tsx
+++ b/src/lib/api/useLogout.spec.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { useLogout } from '~lib/api/useLogout';
 import renderWithProviders from '~lib/test/renderWithProviders';
 

--- a/src/lib/getAppFeatures.tsx
+++ b/src/lib/getAppFeatures.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import root from '~lib/routes';

--- a/src/lib/getSequenceType.tsx
+++ b/src/lib/getSequenceType.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { SequenceContentType } from '~src/__generated__/graphql';

--- a/src/lib/swiper.tsx
+++ b/src/lib/swiper.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import { memo, PropsWithChildren, useEffect, useRef, useState } from 'react';
 import type { Swiper as _Swiper } from 'swiper';
 import type { SwiperProps as _SwiperProps } from 'swiper/react';
 
@@ -36,7 +36,7 @@ function updateSwiper(el: HTMLSwiperElement): boolean {
 	}
 }
 
-const Swiper = React.memo(function Swiper(props: SwiperProps) {
+const Swiper = memo(function Swiper(props: SwiperProps) {
 	const ref = useRef<HTMLSwiperElement>(null);
 	const [retry, setRetry] = useState(0);
 	const router = useRouter();

--- a/src/lib/test/buildLoader.ts
+++ b/src/lib/test/buildLoader.ts
@@ -1,8 +1,8 @@
 import { when } from 'jest-when';
 import defaultsDeep from 'lodash/defaultsDeep';
-import { PartialDeep } from 'type-fest';
 
 import * as api from '~lib/api/fetchApi';
+import { PartialDeepRecursive } from '~src/types/types';
 
 import {
 	createControlledPromise,
@@ -16,14 +16,7 @@ type Options = {
 	variables?: Record<string, unknown>;
 };
 
-type PartialData<T> =
-	| PartialDeep<
-			T,
-			{
-				recurseIntoArrays: true;
-			}
-	  >
-	| Record<string, never>;
+type PartialData<T> = PartialDeepRecursive<T> | Record<string, never>;
 
 type Loader<T> = (
 	data?: PartialData<T>,

--- a/src/lib/test/buildPageRenderer.tsx
+++ b/src/lib/test/buildPageRenderer.tsx
@@ -1,16 +1,12 @@
 import { __mockedRouter } from 'next/router';
 import { ComponentType } from 'react';
-import { PartialDeep } from 'type-fest';
+
+import { PartialDeepRecursive } from '~src/types/types';
 
 import { buildRenderer, RendererResult } from './buildRenderer';
 
 type PageRendererOptions<T> = {
-	props?: PartialDeep<
-		T,
-		{
-			recurseIntoArrays: true;
-		}
-	>;
+	props?: PartialDeepRecursive<T>;
 };
 
 export type PageRenderer<T> = (
@@ -25,7 +21,5 @@ export function buildPageRenderer<T extends Record<string, unknown>>(
 ): PageRenderer<T> {
 	const { getProps } = options;
 	const r = buildRenderer(Page);
-	return async () => {
-		return r({ props: await getProps(__mockedRouter.query) });
-	};
+	return async () => r({ props: await getProps(__mockedRouter.query) });
 }

--- a/src/lib/test/buildPageRenderer.tsx
+++ b/src/lib/test/buildPageRenderer.tsx
@@ -1,0 +1,32 @@
+import { QueryClient } from '@tanstack/react-query';
+import { RenderResult } from '@testing-library/react';
+import { __mockedRouter } from 'next/router';
+import { ComponentType } from 'react';
+
+import { buildRenderer } from './buildRenderer';
+
+// TODO: Only accept props if getProps not provided
+// TODO: Only accept params if getProps provided
+type PageRendererOptions = {
+	props?: any; // TODO: restrict to props component actually accepts
+};
+
+export type PageRenderer = (
+	options?: PageRendererOptions
+) => Promise<RenderResult & { queryClient: QueryClient }>;
+
+export function buildPageRenderer<
+	C extends ComponentType<any>,
+	F extends (params: any) => Promise<any>
+>(
+	Page: C,
+	options: {
+		getProps: F;
+	}
+): PageRenderer {
+	const { getProps } = options;
+	const r = buildRenderer(Page);
+	return async (): Promise<RenderResult & { queryClient: QueryClient }> => {
+		return r({ props: await getProps(__mockedRouter.query) });
+	};
+}

--- a/src/lib/test/buildRenderer.tsx
+++ b/src/lib/test/buildRenderer.tsx
@@ -2,19 +2,17 @@ import { QueryClient } from '@tanstack/react-query';
 import { RenderResult } from '@testing-library/react';
 import { __mockedRouter } from 'next/router';
 import React, { ComponentType } from 'react';
-import { PartialDeep } from 'type-fest';
 
 import renderWithProviders from '~lib/test/renderWithProviders';
+import { PartialDeepRecursive } from '~src/types/types';
 
 type RendererOptions<T> = {
-	props?: PartialDeep<T, { recurseIntoArrays: true }>;
+	props?: PartialDeepRecursive<T>;
 };
 
 export type RendererResult<T> = Omit<RenderResult, 'rerender'> & {
 	queryClient: QueryClient;
-	rerender: (
-		rerenderProps?: PartialDeep<T, { recurseIntoArrays: true }>
-	) => void;
+	rerender: (rerenderProps?: PartialDeepRecursive<T>) => void;
 };
 
 export type Renderer<T> = (
@@ -24,7 +22,7 @@ export type Renderer<T> = (
 export function buildRenderer<T extends Record<string, any>>(
 	Component: ComponentType<T>,
 	options: {
-		defaultProps?: PartialDeep<T, { recurseIntoArrays: true }>;
+		defaultProps?: PartialDeepRecursive<T>;
 	} = {}
 ): Renderer<T> {
 	const { defaultProps = {} } = options;
@@ -35,11 +33,9 @@ export function buildRenderer<T extends Record<string, any>>(
 		const r = await renderWithProviders(<Component {...p} />);
 		return {
 			...r,
-			rerender: (
-				rerenderProps?: PartialDeep<T, { recurseIntoArrays: true }>
-			) => {
+			rerender: (rerenderProps?: PartialDeepRecursive<T>) => {
 				const rp = { ...p, ...(rerenderProps || {}) };
-				return r.rerender(<Component {...rp} />);
+				r.rerender(<Component {...rp} />);
 			},
 		};
 	};

--- a/src/lib/test/buildRenderer.tsx
+++ b/src/lib/test/buildRenderer.tsx
@@ -1,7 +1,7 @@
 import { QueryClient } from '@tanstack/react-query';
 import { RenderResult } from '@testing-library/react';
 import { __mockedRouter } from 'next/router';
-import React, { ComponentType } from 'react';
+import { ComponentType } from 'react';
 
 import renderWithProviders from '~lib/test/renderWithProviders';
 import { PartialDeepRecursive } from '~src/types/types';

--- a/src/lib/test/buildServerRenderer.ts
+++ b/src/lib/test/buildServerRenderer.ts
@@ -1,19 +1,19 @@
 import { GetServerSidePropsResult } from 'next';
 import { ComponentType } from 'react';
 
-import { buildRenderer, Renderer } from '~lib/test/buildRenderer';
+import { Renderer } from '~lib/test/buildRenderer';
 
-export function buildServerRenderer<
-	C extends ComponentType<any>,
-	F extends (context: any) => Promise<GetServerSidePropsResult<any>>
->(Component: C, getServerSideProps: F): Renderer {
+import { buildPageRenderer } from './buildPageRenderer';
+
+export function buildServerRenderer<T>(
+	Component: ComponentType<T>,
+	getServerSideProps: (context: any) => Promise<GetServerSidePropsResult<any>>
+): Renderer<T> {
 	const getProps = async (p: any) => {
-		const result = await getServerSideProps({ params: p, query: p } as any);
-		if (!('props' in result)) {
-			throw new Error('Failed to get server props');
-		}
-		return result.props;
+		const r = await getServerSideProps({ params: p, query: p } as any);
+		if (!('props' in r)) throw new Error('Failed to get server props');
+		return r.props;
 	};
 
-	return buildRenderer(Component, { getProps });
+	return buildPageRenderer(Component, { getProps });
 }

--- a/src/lib/test/buildServerRenderer.ts
+++ b/src/lib/test/buildServerRenderer.ts
@@ -1,14 +1,12 @@
 import { GetServerSidePropsResult } from 'next';
 import { ComponentType } from 'react';
 
-import { Renderer } from '~lib/test/buildRenderer';
+import { buildPageRenderer, PageRenderer } from './buildPageRenderer';
 
-import { buildPageRenderer } from './buildPageRenderer';
-
-export function buildServerRenderer<T>(
+export function buildServerRenderer<T extends Record<string, unknown>>(
 	Component: ComponentType<T>,
 	getServerSideProps: (context: any) => Promise<GetServerSidePropsResult<any>>
-): Renderer<T> {
+): PageRenderer<T> {
 	const getProps = async (p: any) => {
 		const r = await getServerSideProps({ params: p, query: p } as any);
 		if (!('props' in r)) throw new Error('Failed to get server props');

--- a/src/lib/test/buildStaticRenderer.ts
+++ b/src/lib/test/buildStaticRenderer.ts
@@ -1,14 +1,12 @@
 import { GetStaticProps } from 'next';
 import { ComponentType } from 'react';
 
-import { Renderer } from '~lib/test/buildRenderer';
-
-import { buildPageRenderer } from './buildPageRenderer';
+import { buildPageRenderer, PageRenderer } from './buildPageRenderer';
 
 export function buildStaticRenderer<T extends Record<string, any>>(
 	Component: ComponentType<T>,
 	getStaticProps: GetStaticProps<any, any>
-): Renderer<T> {
+): PageRenderer<T> {
 	const getProps = async (p: any) =>
 		((await getStaticProps({ params: p })) as any).props;
 

--- a/src/lib/test/buildStaticRenderer.ts
+++ b/src/lib/test/buildStaticRenderer.ts
@@ -1,14 +1,16 @@
 import { GetStaticProps } from 'next';
 import { ComponentType } from 'react';
 
-import { buildRenderer, Renderer } from '~lib/test/buildRenderer';
+import { Renderer } from '~lib/test/buildRenderer';
 
-export function buildStaticRenderer<
-	C extends ComponentType<any>,
-	F extends GetStaticProps<any, any>
->(Component: C, getStaticProps: F): Renderer {
+import { buildPageRenderer } from './buildPageRenderer';
+
+export function buildStaticRenderer<T extends Record<string, any>>(
+	Component: ComponentType<T>,
+	getStaticProps: GetStaticProps<any, any>
+): Renderer<T> {
 	const getProps = async (p: any) =>
 		((await getStaticProps({ params: p })) as any).props;
 
-	return buildRenderer(Component, { getProps });
+	return buildPageRenderer(Component, { getProps });
 }

--- a/src/lib/test/renderWithProviders.tsx
+++ b/src/lib/test/renderWithProviders.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, RenderOptions, RenderResult } from '@testing-library/react';
-import React from 'react';
 
 import withIntl from '~components/HOCs/withIntl';
 import { __awaitIntlMessages } from '~lib/getIntlMessages';

--- a/src/lib/test/renderWithProviders.tsx
+++ b/src/lib/test/renderWithProviders.tsx
@@ -7,24 +7,35 @@ import { __awaitIntlMessages } from '~lib/getIntlMessages';
 
 import makeQueryClient from '../makeQueryClient';
 
+function withProviders(ui: React.ReactElement, client: QueryClient) {
+	const WithIntl = withIntl(() => ui);
+
+	return function WithProviders() {
+		return (
+			<QueryClientProvider client={client}>
+				<WithIntl />
+			</QueryClientProvider>
+		);
+	};
+}
+
 export default async function renderWithProviders(
 	ui: React.ReactElement,
 	renderOptions?: RenderOptions
 ): Promise<RenderResult & { queryClient: QueryClient }> {
 	const queryClient = makeQueryClient();
-	const WithIntl = withIntl(() => ui);
+	const WithProviders = withProviders(ui, queryClient);
 
-	const result = render(
-		<QueryClientProvider client={queryClient}>
-			<WithIntl />
-		</QueryClientProvider>,
-		renderOptions
-	);
+	const result = render(<WithProviders />, renderOptions);
 
 	await __awaitIntlMessages();
 
 	return {
 		...result,
 		queryClient,
+		rerender: (rerenderUi: React.ReactElement) => {
+			const WithProviders = withProviders(rerenderUi, queryClient);
+			return result.rerender(<WithProviders />);
+		},
 	};
 }

--- a/src/lib/test/renderWithProviders.tsx
+++ b/src/lib/test/renderWithProviders.tsx
@@ -35,7 +35,7 @@ export default async function renderWithProviders(
 		queryClient,
 		rerender: (rerenderUi: React.ReactElement) => {
 			const WithProviders = withProviders(rerenderUi, queryClient);
-			return result.rerender(<WithProviders />);
+			result.rerender(<WithProviders />);
 		},
 	};
 }

--- a/src/lib/useNavigationItems.tsx
+++ b/src/lib/useNavigationItems.tsx
@@ -1,6 +1,5 @@
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
-import React from 'react';
 import { useIntl } from 'react-intl';
 
 import DownloadAppButton from '~components/molecules/downloadAppButton';

--- a/src/lib/usePlaybackSession.tsx
+++ b/src/lib/usePlaybackSession.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 
 import {
 	AndMiniplayerFragment,

--- a/src/pages/[language]/account/logout.tsx
+++ b/src/pages/[language]/account/logout.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { useLogout } from '~lib/api/useLogout';

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,4 @@
 import Document, { Head, Html, Main, NextScript } from 'next/document';
-import React from 'react';
 
 class MyDocument extends Document {
 	render() {

--- a/src/types/swiper.d.ts
+++ b/src/types/swiper.d.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { SwiperProps, SwiperSlideProps } from 'swiper/react';
 
 declare global {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,3 +1,5 @@
+import { PartialDeep } from 'type-fest';
+
 type ExactAlt<T, Shape> = T extends Shape
 	? Exclude<keyof T, keyof Shape> extends never
 		? T
@@ -8,3 +10,10 @@ type ExactAlt<T, Shape> = T extends Shape
 type Must<T> = {
 	[P in keyof T]-?: NonNullable<T[P]>;
 };
+
+type PartialDeepRecursive<T> = PartialDeep<
+	T,
+	{
+		recurseIntoArrays: true;
+	}
+>;

--- a/testSetup.ts
+++ b/testSetup.ts
@@ -14,6 +14,39 @@ jest.mock('~lib/getIntlMessages');
 jest.mock('~lib/makeQueryClient');
 jest.mock('~lib/swiper');
 
+interface CustomMatchers<R = unknown> {
+	toAppearBefore: (argument: HTMLElement) => R;
+}
+
+declare global {
+	/* eslint-disable */
+	// https://jestjs.io/docs/26.x/expect#expectextendmatchers
+	namespace jest {
+		interface Expect extends CustomMatchers {}
+		interface Matchers<R> extends CustomMatchers<R> {}
+		interface InverseAsymmetricMatchers extends CustomMatchers {}
+	}
+	/* eslint-enable */
+}
+
+expect.extend({
+	toAppearBefore(received: HTMLElement, argument: HTMLElement) {
+		const pass =
+			received.compareDocumentPosition(argument) &
+			Node.DOCUMENT_POSITION_FOLLOWING;
+
+		return pass
+			? {
+					message: () => `expected ${received} not to be before ${argument}`,
+					pass: true,
+			  }
+			: {
+					message: () => `expected ${received} to be before ${argument}`,
+					pass: false,
+			  };
+	},
+});
+
 // WORKAROUND: https://github.com/keppelen/react-facebook-login/issues/217#issuecomment-375652793
 beforeAll(() => {
 	const fbScript = document.createElement('script');

--- a/testSetup.ts
+++ b/testSetup.ts
@@ -31,19 +31,18 @@ declare global {
 
 expect.extend({
 	toAppearBefore(received: HTMLElement, argument: HTMLElement) {
-		const pass =
+		const pass = !!(
 			received.compareDocumentPosition(argument) &
-			Node.DOCUMENT_POSITION_FOLLOWING;
+			Node.DOCUMENT_POSITION_FOLLOWING
+		);
 
-		return pass
-			? {
-					message: () => `expected ${received} not to be before ${argument}`,
-					pass: true,
-			  }
-			: {
-					message: () => `expected ${received} to be before ${argument}`,
-					pass: false,
-			  };
+		return {
+			message: () =>
+				pass
+					? `expected ${received} not to be before ${argument}`
+					: `expected ${received} to be before ${argument}`,
+			pass,
+		};
 	},
 });
 


### PR DESCRIPTION
This PR disables the `react/react-in-jsx-scope` rule. This rule is no longer needed when using a newer version of the JSX transform. This PR also refactors our React imports to remove the unneeded default import.

Reference:

- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
- https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports