### PR TITLE
improve: pre-commit hook by only running against staged(modified) files

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,11 +43,11 @@ jobs:
             ${{github.event.deployment_status.target_url}}/
             ${{github.event.deployment_status.target_url}}/en
             ${{github.event.deployment_status.target_url}}/es
-            ${{github.event.deployment_status.target_url}}/en/discover
             ${{github.event.deployment_status.target_url}}/en/teachings/all/page/1
             ${{github.event.deployment_status.target_url}}/en/teachings/300
             ${{github.event.deployment_status.target_url}}/en/bibles/ENGKJV2
             ${{github.event.deployment_status.target_url}}/en/presenters/1309/amanda-anguish
+          # ${{github.event.deployment_status.target_url}}/en/discover
           runs: 3
           temporaryPublicStorage: true
       - name: Add comment

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -11,4 +11,6 @@ elif command -v asdf >/dev/null 2>&1; then
     asdf shell nodejs $version
 fi
 
-npm run precommit
+# npm run precommit
+echo "Commencing lint-staged"
+npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,6 +117,7 @@
                 "jest-environment-jsdom": "^29.7.0",
                 "jest-when": "^3.6.0",
                 "knip": "^5.44.5",
+                "lint-staged": "^16.0.0",
                 "nextjs-bundle-analysis": "^0.5.0",
                 "pa11y-ci": "^3.1.0",
                 "prettier": "^3.3.3",
@@ -7353,24 +7354,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@puppeteer/browsers/node_modules/debug": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@puppeteer/browsers/node_modules/semver": {
             "version": "7.6.3",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -12249,11 +12232,12 @@
             "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -12859,6 +12843,19 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/environment": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/error-ex": {
@@ -14032,6 +14029,13 @@
                 "through": "^2.3.8"
             }
         },
+        "node_modules/eventemitter3": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+            "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/events": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -14920,6 +14924,19 @@
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+            "integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/get-intrinsic": {
@@ -19648,10 +19665,361 @@
                 "node": ">=12"
             }
         },
+        "node_modules/lilconfig": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+            "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antonk52"
+            }
+        },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+        },
+        "node_modules/lint-staged": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.0.0.tgz",
+            "integrity": "sha512-sUCprePs6/rbx4vKC60Hez6X10HPkpDJaGcy3D1NdwR7g1RcNkWL8q9mJMreOqmHBTs+1sNFp+wOiX9fr+hoOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^5.4.1",
+                "commander": "^13.1.0",
+                "debug": "^4.4.0",
+                "lilconfig": "^3.1.3",
+                "listr2": "^8.3.3",
+                "micromatch": "^4.0.8",
+                "nano-spawn": "^1.0.0",
+                "pidtree": "^0.6.0",
+                "string-argv": "^0.3.2",
+                "yaml": "^2.7.1"
+            },
+            "bin": {
+                "lint-staged": "bin/lint-staged.js"
+            },
+            "engines": {
+                "node": ">=20.18"
+            },
+            "funding": {
+                "url": "https://opencollective.com/lint-staged"
+            }
+        },
+        "node_modules/lint-staged/node_modules/ansi-escapes": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+            "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "environment": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/ansi-regex": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/lint-staged/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/lint-staged/node_modules/chalk": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+            "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/lint-staged/node_modules/cli-cursor": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "restore-cursor": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/cli-truncate": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+            "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "slice-ansi": "^5.0.0",
+                "string-width": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/commander": {
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/lint-staged/node_modules/is-fullwidth-code-point": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+            "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/listr2": {
+            "version": "8.3.3",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
+            "integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cli-truncate": "^4.0.0",
+                "colorette": "^2.0.20",
+                "eventemitter3": "^5.0.1",
+                "log-update": "^6.1.0",
+                "rfdc": "^1.4.1",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/lint-staged/node_modules/log-update": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+            "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-escapes": "^7.0.0",
+                "cli-cursor": "^5.0.0",
+                "slice-ansi": "^7.1.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/log-update/node_modules/is-fullwidth-code-point": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+            "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-east-asian-width": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/log-update/node_modules/slice-ansi": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+            "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/lint-staged/node_modules/onetime": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-function": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/restore-cursor": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/lint-staged/node_modules/slice-ansi": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+            "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.0.0",
+                "is-fullwidth-code-point": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/lint-staged/node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lint-staged/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/lint-staged/node_modules/wrap-ansi": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+            "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/lint-staged/node_modules/yaml": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            }
         },
         "node_modules/listr2": {
             "version": "4.0.5",
@@ -20211,6 +20579,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/min-document": {
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -20332,9 +20713,10 @@
             }
         },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
         },
         "node_modules/mustache": {
             "version": "4.2.0",
@@ -20366,6 +20748,19 @@
             "engines": {
                 "node": ">=8",
                 "npm": ">=5"
+            }
+        },
+        "node_modules/nano-spawn": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.1.tgz",
+            "integrity": "sha512-BfcvzBlUTxSDWfT+oH7vd6CbUV+rThLLHCIym/QO6GGLBsyVXleZs00fto2i2jzC/wPiBYk5jyOmpXWg4YopiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
             }
         },
         "node_modules/nanoid": {
@@ -21664,6 +22059,19 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/pidtree": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+            "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "pidtree": "bin/pidtree.js"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
         "node_modules/pify": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -22042,24 +22450,6 @@
             },
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/debug": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/puppeteer/node_modules/agent-base": {
@@ -22643,9 +23033,10 @@
             }
         },
         "node_modules/rfdc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+            "license": "MIT"
         },
         "node_modules/rimraf": {
             "version": "3.0.2",
@@ -22960,12 +23351,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/send/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
         },
         "node_modules/sentence-case": {
             "version": "3.0.4",
@@ -23495,6 +23880,16 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/string-argv": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+            "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6.19"
+            }
         },
         "node_modules/string-env-interpolation": {
             "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "jest-when": "^3.6.0",
         "knip": "^5.44.5",
+        "lint-staged": "^16.0.0",
         "nextjs-bundle-analysis": "^0.5.0",
         "pa11y-ci": "^3.1.0",
         "prettier": "^3.3.3",
@@ -176,5 +177,23 @@
     },
     "engines": {
         "node": "20.17.0"
+    },
+    "husky": {
+        "hooks": {
+        "pre-commit": "lint-staged --debug"
+        }
+    },
+    "lint-staged": {
+        "*.{ts,tsx}": [
+            "prettier --write",
+            "eslint --fix",
+            "bash -c tsc --noEmit"
+        ],
+        "*.{json,scss,graphql}": [
+            "prettier --write"
+        ],
+        "public/lang/*.json": [
+            "npm:intl"
+        ]
     }
 }

--- a/src/containers/base.tsx
+++ b/src/containers/base.tsx
@@ -1,3 +1,4 @@
+// This is just a test line to trigger the pre-commit hook
 import {
 	DehydratedState,
 	HydrationBoundary,

--- a/src/containers/base.tsx
+++ b/src/containers/base.tsx
@@ -1,4 +1,3 @@
-// This is just a test line to trigger the pre-commit hook
 import {
 	DehydratedState,
 	HydrationBoundary,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,6 @@
 		},
 		"incremental": true
 	},
-	"exclude": ["./*.js", "**/*.graphql"],
+	"exclude": ["./*.js", "**/*.graphql", "node_modules"],
 	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
Previously pre-commit ran across all the files, making the commit process slower than it needs to be.
Now with the help of lint-staged, the commits should be faster as linter, tsc, prettier etc will only be run on staged/modified files opposed to entire repo.
